### PR TITLE
docs(ray): clarify background param and add notes section

### DIFF
--- a/skills/ray/SKILL.md
+++ b/skills/ray/SKILL.md
@@ -26,9 +26,15 @@ Content-Type: application/json
 | `fontSize` | number | `14` | 8-32 |
 | `lineNumbers` | boolean | `true` | |
 | `title` | string | `""` | Window chrome title (max 100) |
-| `background` | string | `"midnight"` | midnight, sunset, ocean, forest, ember, steel, aurora, none |
+| `background` | string | `"midnight"` | One of: midnight, sunset, ocean, forest, ember, steel, aurora, none. Hex colors are not accepted. |
 | `format` | `"png"` | `"png"` | PNG only |
 | `scale` | number | `2` | 1-4 (retina) |
+
+## Notes
+
+- `background: "none"` returns a transparent RGBA PNG. Useful when you want to composite the screenshot onto a custom background.
+- Returned PNGs always include some transparent margin around the window for the drop shadow, even with `padding: 0`. If you're compositing the result, trim that halo first (e.g. `magick input.png -trim +repage output.png`).
+- Long snippets can take 30-60+ seconds to render. Use a per-request timeout when calling from scripts or agents.
 
 ## Workflow
 


### PR DESCRIPTION
This PR makes a few small corrections to the \`ray\` skill's SKILL.md based on practical use against the live API.

Changes:

- The \`background\` parameter row is clarified to make explicit that hex colors are not accepted. The runtime API only accepts the listed preset names; passing a hex string returns a 400 with the enum list. (The public docs page at https://ray.tinte.dev/docs still mentions hex, which led to the confusion.)
- Added a small Notes section covering three things that come up when using the API in real scripts/agents:
  - \`background: \"none\"\` returns a transparent RGBA PNG, which is the right choice when compositing onto a custom background.
  - Returned PNGs include a transparent margin around the window for the drop shadow, even with \`padding: 0\`. If you're compositing, you'll want to trim that halo first.
  - Long snippets can take 30-60+ seconds to render. Per-request timeouts are a good idea.

No code changes, just SKILL.md.