### PR TITLE
feat: design system to Agent Plugin compiler (build, lint, from)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,7 @@
       "devDependencies": {
         "@types/culori": "^4.0.0",
         "@types/node": "^20.0.0",
+        "bun-types": "^1.3.14",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.0.0",
@@ -1841,6 +1842,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "tinte",
-      "dependencies": {
-        "next": "16.2.6",
-      },
       "devDependencies": {
         "@biomejs/biome": "2.2.0",
         "simple-git-hooks": "^2.13.1",
@@ -194,7 +191,12 @@
       "bin": {
         "tinte": "dist/cli.js",
       },
+      "dependencies": {
+        "@tinte/core": "workspace:*",
+        "culori": "^4.0.2",
+      },
       "devDependencies": {
+        "@types/culori": "^4.0.0",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
@@ -2090,7 +2092,7 @@
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+    "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
@@ -3168,7 +3170,7 @@
 
     "polished": ["polished@4.3.1", "", { "dependencies": { "@babel/runtime": "^7.17.8" } }, "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA=="],
 
-    "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
@@ -3982,8 +3984,6 @@
 
     "@jimp/core/file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
-    "@mapbox/node-pre-gyp/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
-
     "@mapbox/node-pre-gyp/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "@modelcontextprotocol/sdk/express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
@@ -4088,8 +4088,6 @@
 
     "@tailwindcss/node/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 
-    "@tailwindcss/oxide/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.5.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ=="],
@@ -4101,8 +4099,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@tailwindcss/postcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "@textlint/linter-formatter/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4145,8 +4141,6 @@
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/compiler-sfc/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
-
-    "@vue/compiler-sfc/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "@whatwg-node/fetch/urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
 
@@ -4218,15 +4212,11 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "css-loader/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
     "css-loader/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "decompress-response/mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
-    "detective-postcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "dom-helpers/@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
@@ -4328,8 +4318,6 @@
 
     "light-my-request/cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
 
-    "lightningcss/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
-
     "listhen/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "listhen/std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
@@ -4361,6 +4349,8 @@
     "netlify-cli/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "netlify-cli/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "node-source-walk/@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
 
@@ -4394,15 +4384,11 @@
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "prebuild-install/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
-
     "prebuild-install/minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "prebuild-install/pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "precinct/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
-    "precinct/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "prettyjson/minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -4444,9 +4430,9 @@
 
     "send/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
-    "shadcn/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -4517,8 +4503,6 @@
     "update-notifier/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "vite/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
-
-    "vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "wait-port/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4864,8 +4848,6 @@
 
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "@textlint/linter-formatter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "@textlint/linter-formatter/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -4891,8 +4873,6 @@
     "@vue/compiler-core/@babel/parser/@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "@vue/compiler-sfc/@babel/parser/@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
-
-    "@vue/compiler-sfc/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@xhmikosr/downloader/p-event/p-timeout": ["p-timeout@5.1.0", "", {}, "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="],
 
@@ -4936,11 +4916,7 @@
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "css-loader/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
-
-    "detective-postcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -5020,8 +4996,6 @@
 
     "ipx/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.3", "", { "os": "win32", "cpu": "x64" }, "sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g=="],
 
-    "ipx/sharp/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
-
     "isomorphic-fetch/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
@@ -5048,6 +5022,8 @@
 
     "netlify-cli/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
+    "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "node-source-walk/@babel/parser/@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "node-vibrant/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
@@ -5058,8 +5034,6 @@
 
     "parallel-transform/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
-    "precinct/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
     "read-pkg/parse-json/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
@@ -5069,8 +5043,6 @@
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "shadcn/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -5243,8 +5215,6 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
-
-    "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "webpack/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.8.2", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-NvcIedLxrs9llVpX7wI+Jz4Hn9vJQkCPKrTaHIE0sW/Rj1iq6Fzby4NbyTZjQJNoypBXNaG7tEHkTgONZpwgxQ=="],
 

--- a/packages/cli/assets/extract.js
+++ b/packages/cli/assets/extract.js
@@ -1,0 +1,147 @@
+// tinte from --emit-script
+// Standalone browser-eval script for `agent-browser eval`. No imports, no
+// external deps - runs in the page context. Walks every visible element,
+// reads computed styles, and accumulates candidates weighted by painted
+// area (rect.width * rect.height) and occurrence count. Also attempts to
+// read document.styleSheets as a bonus signal (cross-origin sheets throw
+// SecurityError and are recorded as blocked, never fatal).
+//
+// Output shape MUST match spike-data/vercel.json - that file is the
+// contract other tooling (`tinte from --normalize`) is built against.
+(function extract() {
+  const bgColors = new Map(); // color -> { area, count }
+  const textColors = new Map();
+  const fontFamilies = new Set();
+  const fontSizes = new Map(); // size -> count
+  const fontWeights = new Set();
+  const lineHeights = new Set();
+  const radii = new Map(); // radius -> count
+  const shadows = new Map(); // shadow -> count
+
+  const allElements = document.querySelectorAll("*");
+  let visibleCount = 0;
+
+  function isVisible(el, style) {
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    if (Number.parseFloat(style.opacity) === 0) return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  function bump(map, key) {
+    if (!key) return;
+    const existing = map.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      map.set(key, { count: 1 });
+    }
+  }
+
+  function bumpWithArea(map, key, area) {
+    if (!key) return;
+    const existing = map.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.area = Math.max(existing.area, area);
+    } else {
+      map.set(key, { count: 1, area });
+    }
+  }
+
+  function isTransparent(color) {
+    if (!color) return true;
+    if (color === "transparent") return true;
+    const rgbaMatch = color.match(
+      /rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*(?:,\s*([\d.]+)\s*)?\)/,
+    );
+    if (rgbaMatch && rgbaMatch[1] !== undefined) {
+      return Number.parseFloat(rgbaMatch[1]) === 0;
+    }
+    return false;
+  }
+
+  for (const el of allElements) {
+    const style = getComputedStyle(el);
+    if (!isVisible(el, style)) continue;
+    visibleCount += 1;
+
+    const rect = el.getBoundingClientRect();
+    const area = Math.round(rect.width * rect.height);
+
+    const bg = style.backgroundColor;
+    if (!isTransparent(bg)) {
+      bumpWithArea(bgColors, bg, area);
+    }
+
+    const color = style.color;
+    if (!isTransparent(color)) {
+      bumpWithArea(textColors, color, area);
+    }
+
+    if (style.fontFamily) fontFamilies.add(style.fontFamily);
+    if (style.fontSize) bump(fontSizes, style.fontSize);
+    if (style.fontWeight) fontWeights.add(style.fontWeight);
+    if (style.lineHeight) lineHeights.add(style.lineHeight);
+
+    const borderRadius = style.borderRadius;
+    if (borderRadius && borderRadius !== "0px") {
+      radii.set(borderRadius, (radii.get(borderRadius) || 0) + 1);
+    }
+
+    const boxShadow = style.boxShadow;
+    if (boxShadow && boxShadow !== "none") {
+      shadows.set(boxShadow, (shadows.get(boxShadow) || 0) + 1);
+    }
+  }
+
+  function toSortedByAreaArray(map) {
+    return Array.from(map.entries())
+      .map(([color, v]) => ({ color, area: v.area, count: v.count }))
+      .sort((a, b) => b.area - a.area);
+  }
+
+  function toSortedEntryArray(map) {
+    return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
+  }
+
+  const fontSizesSorted = Array.from(fontSizes.entries())
+    .map(([size, count]) => ({ size, count }))
+    .sort((a, b) => Number.parseFloat(a.size) - Number.parseFloat(b.size));
+
+  const styleSheets = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    const href = sheet.href || "(inline)";
+    try {
+      const ruleCount = sheet.cssRules.length;
+      styleSheets.push({ href, ok: true, ruleCount });
+    } catch (error) {
+      styleSheets.push({
+        href,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const result = {
+    fontFamilies: Array.from(fontFamilies),
+    fontSizesSorted,
+    fontWeights: Array.from(fontWeights).sort(
+      (a, b) => Number.parseFloat(a) - Number.parseFloat(b),
+    ),
+    lineHeights: Array.from(lineHeights),
+    styleSheets,
+    topBgColorsByArea: toSortedByAreaArray(bgColors).slice(0, 20),
+    topTextColorsByArea: toSortedByAreaArray(textColors).slice(0, 20),
+    totalElements: allElements.length,
+    uniqueBgColors: bgColors.size,
+    uniqueRadii: toSortedEntryArray(radii),
+    uniqueShadows: toSortedEntryArray(shadows),
+    uniqueTextColors: textColors.size,
+    visibleElements: visibleCount,
+  };
+
+  console.log(JSON.stringify(result));
+  return result;
+})();

--- a/packages/cli/assets/templates/landing.md
+++ b/packages/cli/assets/templates/landing.md
@@ -1,0 +1,295 @@
+---
+name: {{brand_name}}-landing
+description: "Design or substantially improve a landing page for {{brand_name}}. Use when building a marketing site, hero section, product page, pricing page, or any page whose job is to make a first-time visitor understand and want the product. Carries {{brand_name}} composition rules, type scale, voice, and token API."
+---
+
+# Design a landing page like {{brand_name}}
+
+Act as an excellent designer, editor, and design engineer working on {{brand_name}}'s
+own marketing surface. Shape the argument and the interface together. Do not restyle a
+feature list into components.
+
+Eighty percent of visitors never scroll past the first viewport. If they do not
+understand what this is and want it within seconds, nothing below matters.
+
+## Priority order
+
+When requirements compete, protect them in this order:
+
+1. Preserve supplied facts, numbers, names, claims, pricing, and task constraints.
+2. Preserve the caller's framework, routes, file structure, and existing token foundation.
+3. Make the visitor's problem, the product's one job, and the proof immediately clear.
+4. Establish unmistakable {{brand_name}} authorship through the token foundation, type
+   scale, and restraint.
+5. Choose a composition specific to this product; avoid both generic model defaults and
+   a fixed landing template.
+6. Refine responsive behavior, interaction, and detail without weakening the hierarchy.
+
+Ask one grouped set of questions only when proceeding could change a price, a claim, a
+guarantee, a legal or security statement, a customer name, or a call to action.
+Otherwise omit the unknown, label it honestly, and proceed.
+
+## Identity injection
+
+This section is the only part of this skill that varies by project. Everything else is
+fixed archetype law.
+
+### Token foundation
+
+Load `{{tokens_css_url}}` once at the nearest shared page boundary. Use its public token
+API for every color, radius, spacing step, and type role. Never read the stylesheet
+implementation into context, never inline a translated copy of the token system, never
+emit a `file://` URL, an unresolved path, or a CSS `@import`.
+
+Every color in the output resolves to a token from that file. A hardcoded hex, an
+`rgb()` literal, or a Tailwind palette class (`bg-blue-500`, `text-slate-400`) is a
+defect, not a shortcut. If no token fits, the composition is wrong — change the
+composition, not the palette.
+
+### Type scale
+
+{{type_scale}}
+
+Use only these roles. Do not create arbitrary font sizes or numeric weights. Equivalent
+peers always share role, size, weight, line-height, and numeric treatment. Never resize
+one peer because its string is longer or its number is larger.
+
+### Voice
+
+Write in these words: {{voice_words}}
+
+Write every headline so a fifth grader gets it. Prefer concrete nouns and active verbs.
+Numbers, not adjectives: "renders in 40ms", not "blazingly fast". No weak quantifiers
+("most", "many", "rarely", "up to"). Second person. Sentence case unless
+{{brand_dos_donts}} says otherwise.
+
+Write copy only this company could write. If a competitor could paste this page onto
+their own domain and change one word, it is too generic — rewrite from what this product
+actually does.
+
+### Brand-specific rules
+
+{{brand_dos_donts}}
+
+These override the archetype defaults below when they conflict, and only then.
+
+## Composition law (fixed — does not vary by brand)
+
+### Frame the visitor's job
+
+Before designing, privately establish:
+
+- Who arrives here, from where, in what state of ignorance?
+- What is the one thing this product does?
+- What pain does the visitor already feel that this removes?
+- What proof makes the claim credible — a number, a demo, a named customer, a repo?
+- What is the single next step?
+
+Support two reading speeds. The **skim path** — headline, subhead, one visual proof, one
+CTA — must carry the whole argument alone. The **evaluation path** — specifics, pricing,
+comparison, docs, objections — preserves the detail for the visitor who is actually
+deciding.
+
+Every section answers a new visitor question. Merge duplicates. Remove ceremony. One
+claim has one home: a later section may add specificity, but a second card grid,
+summary, or closing block must not restate the same claim at equal prominence.
+
+### Choose the composition
+
+The first viewport is the argument, not a masthead followed by setup. Before designing,
+privately name the obvious layout this product category would suggest — then reject it
+unless the material earns it.
+
+When the material admits multiple structures, privately compare two materially different
+composition hypotheses before writing code. Change topology, density, and proof
+placement, not merely palette or component choice.
+
+Match the opening to what the product is:
+
+- **A tool with a visible result** — show the result. The artifact it produces is the
+  hero. Do not describe an output you could display.
+- **A tool whose value is speed or removal of work** — show the before/after, or the
+  command, at full size.
+- **Infrastructure or a primitive** — lead with the one-line integration, real code,
+  correct syntax. The snippet is the hero.
+- **A product with no demonstrable surface** — lead with the strongest specific claim
+  plus its proof. Never invent a hero visual to fill the space.
+
+Choose geometry before components. Map the argument to a visual variable:
+
+- Comparison against an alternative → aligned rows or deliberately contrasted columns on
+  one shared basis.
+- A sequence or workflow → connection and order.
+- Magnitude of the improvement → position or length on a common scale.
+- One decisive number → a single figure at display size, not a row of stat boxes.
+- A capability set → a table or a dense list; not a 3×2 icon-card grid.
+
+Compose the page as a field, not a stack of sections. One page-level throughline. One
+focal object per reading moment, surrounded by a small number of supporting objects and
+enough open space to amplify it. Pace the scroll: vary density and quiet while holding
+one visual grammar. Repetition creates rhythm only when the repeated items are true
+peers; otherwise it is template noise.
+
+Give the page one organizing move that belongs to this product and could not be
+transplanted unchanged onto a competitor's site. It may be a comparison geometry, a live
+demo, a specific diagram, an unusual proof, or the interaction itself. It must clarify,
+not decorate.
+
+### Hierarchy and geometry
+
+Every object aligns to a shared edge, baseline, grid line, or deliberate optical center.
+Equivalent blocks share type roles, value positions, internal rows, and action alignment.
+
+Establish hierarchy through typography and space before surfaces or color. Earn a
+border, card, or background only when it communicates grouping, selection, or state that
+spacing cannot express. Prefer spacing, alignment, and a change in density first.
+
+Vertical rhythm is relational, not uniform:
+
+- Heading → its first paragraph: close.
+- Paragraph → paragraph: one body rhythm.
+- Label → value → detail: identical across peers.
+- Content group → new section: clearly larger.
+- Caption → the thing it qualifies: close enough to read together.
+
+Give every gap one owner. A flow, stack, or grid sets the gap; its children do not add
+competing default margins.
+
+Open space must amplify the focal object. Large empty rectangles caused by an underfilled
+split, an orphaned third item, or a delayed proof are layout failures — reflow or
+rebalance them. Do not force materially unequal claims into equal cells: rank them, group
+them, or give the decisive one more visual consequence so the geometry matches the
+argument.
+
+Keep prose near 60–68 characters per line. Keep body text at a comfortable reading size.
+Never use tiny gray copy to fit more in. Rewrite before shrinking. Fix stranded words in
+large headings by improving the copy or the measure, not by shrinking one element.
+
+### Density
+
+A landing page is not a slide deck. Sections should differ in density on purpose: a dense
+proof block earns the quiet that follows it. If every section is one heading, two lines of
+copy, and three cards at equal weight, the page has no argument — it has a rhythm loop.
+
+Full-viewport sections are a choice, not a default. Do not set `min-h-screen` on every
+band. Content decides height.
+
+### Color and surfaces
+
+Design in the token palette, mostly monochrome. Color carries meaning: state, action, or
+data. One accent owns the primary action. Do not color something merely because it is
+important or favorable.
+
+The page is normally one continuous canvas. Do not wrap every section in a card. Do not
+nest panels. Keep radii consistent with the token foundation.
+
+Light and dark are both first-class if the token file defines both. No visible theme
+switcher unless the product's audience expects one.
+
+Diagnose quantity separately from intensity. If it feels busy, remove or combine content.
+If it feels loud, reduce competing color, scale, weight, borders, surfaces, and motion.
+Restraint must not flatten the page into neutral sameness — preserve one deliberate
+anchor.
+
+### Motion and media
+
+Default to stillness. Add motion only when it explains a state change, preserves
+continuity, or confirms an action. Never reveal every section on scroll, never gate
+reading behind animation, never add parallax, bounce, cinematic transitions, marquees,
+simulated typing cursors, or pulsing status dots. Respect `prefers-reduced-motion`. The
+page must be complete without motion.
+
+Use real screenshots, real diagrams, real customer logos. Never stock imagery, generated
+illustrations, abstract 3D shapes, floating gradient orbs, fake dashboards, or a
+mandatory hero image. Icons are labels, not decoration — no icon tiles, no oversized
+icons, no mixed icon styles.
+
+### Conversion structure
+
+- **One primary CTA.** Every extra button creates hesitation. A secondary link may exist
+  (docs, repo, pricing) but it must be visually subordinate.
+- **The CTA says what happens next.** "Start monitoring" or "Install the CLI", never "Get
+  Started", "Learn More", or "Try it now".
+- **Pricing is reachable from the first viewport** if the product is paid. Visitors read
+  pricing to understand the product, not only its cost.
+- **Proof appears before the second CTA.** Named customers, real numbers, a working demo,
+  or a repo with real stars. A page with zero proof asks strangers to trust blindly.
+- **Compare to the real alternative** when a visitor is obviously switching from
+  something. One honest table on the axes they care about.
+- **The footer is the last thing they see.** Finish it deliberately.
+
+### Accessibility (non-negotiable)
+
+- One descriptive `h1`; ordered headings with no skipped levels; landmarks; skip link.
+- Every interactive element is a real `<button>` or `<a>` — never a `<div onClick>`.
+- Visible `:focus-visible` state on everything focusable. Never `outline: none` without a
+  replacement.
+- Icon-only buttons carry `aria-label`; decorative icons carry `aria-hidden="true"`.
+- Images carry `alt` (or `alt=""` when decorative) and explicit `width`/`height`.
+- Contrast meets WCAG AA. Never encode meaning by color alone.
+- Touch targets ≥ 44×44px. `touch-action: manipulation`.
+- Forms: real `<label>`, correct `type`, `autocomplete`, inline errors, never block paste.
+- Source order is reading order. Flex and grid children get `min-width: 0`.
+
+### Typographic detail
+
+`…` not `...`. Curly quotes. Non-breaking spaces in `10 MB`, `⌘ K`, and brand names.
+`text-wrap: balance` on headings. `tabular-nums` only where numbers align vertically —
+never on a large standalone figure. No em dashes.
+
+## Reject these generated-design reflexes
+
+Do not ship any of these. Each is a recognizable AI-output tell:
+
+- A centered hero with an eyebrow pill, a two-line headline, a gray subheading, and two
+  buttons side by side.
+- A gradient headline, gradient background, gradient border, glow, blob, mesh, aurora,
+  animated grid, dot grid, radial spotlight, glass panel, or noise texture.
+- An all-caps tracked eyebrow, kicker, or overline above a heading.
+- A pill or badge announcing "New", "v2.0", "Backed by X", or "AI-powered" above the
+  headline.
+- A 3×2 grid of feature cards, each with an icon in a rounded tinted square, a
+  three-word title, and one sentence of filler.
+- Emoji used as bullets, section markers, or feature icons.
+- Em dashes.
+- A row of three or more stat boxes when one composed relationship would be clearer.
+- Cards nested inside cards, or borders used to repair weak hierarchy.
+- Fabricated testimonials, invented customer logos, made-up star counts, or placeholder
+  avatars presented as real people.
+- "Trusted by teams at" above logos the product does not actually have.
+- `min-h-screen` on every section, producing identical silhouettes down the page.
+- Repeated "Ready to get started?" closing sections that restate the hero.
+- Every section entering with a fade-up on scroll.
+- Copy that could belong to any product in the category: "Built for modern teams",
+  "Scale with confidence", "Everything you need", "The all-in-one platform".
+- Tiny muted body copy, arbitrary font sizes, inconsistent peer values, misaligned
+  baselines.
+- Icons as decoration, oversized icons, or mixed icon families.
+- A dark rounded rectangle around every visual.
+
+Do not compensate by producing a sterile anti-design template. Restraint is precise
+hierarchy, excellent typography, real proof, strong alignment, and deliberate tension. It
+is not black text, white background, thin rules, and large empty margins.
+
+## Final checks
+
+Render the actual result before calling it done. Inspect the first viewport, the full
+page, and both themes if the tokens define both. Verify responsive reflow.
+
+1. **Squint test.** Blur the page. The dominant claim and the primary action must still
+   be obvious, and the reading path stable. If every block has equal weight, redesign
+   before refining.
+2. **Text-mask test.** Replace every string with gray bars. The hierarchy must still
+   communicate identity, emphasis, grouping, and progression. If the page becomes an
+   undifferentiated stack of equal rectangles, the typography is doing no work.
+3. **Transplant test.** Could this page be a competitor's with one word changed? If yes,
+   the organizing move is missing.
+4. **Token audit.** Grep the output for hex literals, `rgb(`, `hsl(`, and framework
+   palette classes. Every hit is a defect.
+5. **Restraint pass.** Can any surface, border, pill, icon, label, paragraph, or section
+   be removed without losing meaning, affordance, or rhythm? If yes, remove it.
+6. **Access pass.** Headings ordered, focus visible, labels present, contrast met,
+   reflow clean, keyboard path complete.
+
+Fix the highest-impact systemic defect, render again, repeat. Keep this work internal —
+deliver the implementation, not a score, a critique, or a process diary.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,11 +38,12 @@
     "url": "https://github.com/Railly/tinte/issues"
   },
   "devDependencies": {
+    "@types/culori": "^4.0.0",
     "@types/node": "^20.0.0",
+    "bun-types": "^1.3.14",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.0.0",
-    "@types/culori": "^4.0.0"
+    "typescript": "^5.0.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,8 @@
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@types/culori": "^4.0.0"
   },
   "engines": {
     "node": ">=16.0.0"
@@ -52,5 +53,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@tinte/core": "workspace:*",
+    "culori": "^4.0.2"
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,9 +1,25 @@
+import { buildCommand } from "./commands/build";
+import { fromCommand } from "./commands/from";
+import { lintCommand } from "./commands/lint";
 import { TinteCLI } from "./tinte-cli";
 import type { EditorInstallOptions } from "./types";
 
 // CLI Interface
 async function main() {
   const args = process.argv.slice(2);
+
+  switch (args[0]) {
+    case "build":
+      process.exit(await buildCommand(args.slice(1)));
+      break;
+    case "lint":
+      process.exit(await lintCommand(args.slice(1)));
+      break;
+    case "from":
+      process.exit(await fromCommand(args.slice(1)));
+      break;
+  }
+
   const cli = new TinteCLI();
 
   if (args.length === 0) {
@@ -16,6 +32,12 @@ Usage:
   bunx tinte <theme.json>            # Install theme from local file
   bunx tinte list                    # List installed Tinte themes
   bunx tinte cleanup                 # Clean up temporary files
+
+Design system compiler (Agent Plugins):
+  bunx tinte build --plugin          # Compile identity config to an Agent Plugin
+  bunx tinte lint [paths...]         # Scan for colors that bypass the token system
+  bunx tinte from --emit-script      # Print the agent-browser extraction script
+  bunx tinte from --normalize <json> # Normalize extracted candidates to a draft identity
 
 Options:
   --light                           # Install light variant

--- a/packages/cli/src/commands/__fixtures__/vercel-candidates.json
+++ b/packages/cli/src/commands/__fixtures__/vercel-candidates.json
@@ -1,0 +1,199 @@
+{
+  "fontFamilies": [
+    "GeistSans, \"GeistSans Fallback\"",
+    "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, \"Liberation Mono\", \"DejaVu Sans Mono\", \"Courier New\", monospace, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+  ],
+  "fontSizesSorted": [
+    {
+      "count": 10,
+      "size": "11px"
+    },
+    {
+      "count": 14,
+      "size": "12px"
+    },
+    {
+      "count": 1,
+      "size": "13px"
+    },
+    {
+      "count": 295,
+      "size": "14px"
+    },
+    {
+      "count": 166,
+      "size": "16px"
+    },
+    {
+      "count": 9,
+      "size": "24px"
+    },
+    {
+      "count": 5,
+      "size": "56px"
+    },
+    {
+      "count": 1,
+      "size": "64px"
+    }
+  ],
+  "fontWeights": ["400", "450", "500"],
+  "lineHeights": [
+    "24px",
+    "20px",
+    "21px",
+    "32px",
+    "64px",
+    "56px",
+    "16.5px",
+    "26.4px",
+    "16px"
+  ],
+  "styleSheets": [
+    {
+      "href": "(inline)",
+      "ok": true,
+      "ruleCount": 1
+    },
+    {
+      "href": "https://vercel.com/vc-ap-vercel-marketing/_next/static/immutable/chunks/2lvhtu0pnzc8w.css",
+      "ok": true,
+      "ruleCount": 345
+    },
+    {
+      "href": "https://vercel.com/vc-ap-vercel-marketing/_next/static/immutable/chunks/014kt2ej08vp4.css",
+      "ok": true,
+      "ruleCount": 672
+    },
+    {
+      "href": "https://vercel.com/vc-ap-vercel-marketing/_next/static/immutable/chunks/3c2di4uzu6g1i.css",
+      "ok": true,
+      "ruleCount": 657
+    },
+    {
+      "href": "https://vercel.com/vc-ap-vercel-marketing/_next/static/immutable/chunks/3u82rwmj_1n8p.css",
+      "ok": true,
+      "ruleCount": 71
+    },
+    {
+      "href": "(inline)",
+      "ok": true,
+      "ruleCount": 1
+    },
+    {
+      "href": "(inline)",
+      "ok": true,
+      "ruleCount": 1
+    }
+  ],
+  "topBgColorsByArea": [
+    {
+      "area": 13608300,
+      "color": "rgb(0, 0, 0)",
+      "count": 6
+    },
+    {
+      "area": 403343,
+      "color": "rgb(237, 237, 237)",
+      "count": 6
+    },
+    {
+      "area": 318782,
+      "color": "lab(0 0 0)",
+      "count": 1
+    },
+    {
+      "area": 198360,
+      "color": "rgb(10, 10, 10)",
+      "count": 7
+    },
+    {
+      "area": 113243,
+      "color": "lab(7.78201 -0.0000149012 0)",
+      "count": 2
+    },
+    {
+      "area": 100,
+      "color": "rgb(136, 136, 136)",
+      "count": 1
+    },
+    {
+      "area": 24,
+      "color": "rgb(46, 46, 46)",
+      "count": 1
+    }
+  ],
+  "topTextColorsByArea": [
+    {
+      "area": 73183352,
+      "color": "rgb(237, 237, 237)",
+      "count": 252
+    },
+    {
+      "area": 748815,
+      "color": "rgb(161, 161, 161)",
+      "count": 203
+    },
+    {
+      "area": 40882,
+      "color": "lab(80.976 0 -0.0000119209)",
+      "count": 12
+    },
+    {
+      "area": 18419,
+      "color": "rgb(10, 10, 10)",
+      "count": 6
+    },
+    {
+      "area": 3947,
+      "color": "rgb(143, 143, 143)",
+      "count": 13
+    },
+    {
+      "area": 2386,
+      "color": "rgb(255, 255, 255)",
+      "count": 2
+    },
+    {
+      "area": 2160,
+      "color": "rgb(136, 136, 136)",
+      "count": 1
+    },
+    {
+      "area": 2139,
+      "color": "rgb(135, 135, 135)",
+      "count": 6
+    },
+    {
+      "area": 693,
+      "color": "rgb(98, 192, 115)",
+      "count": 3
+    }
+  ],
+  "totalElements": 1112,
+  "uniqueBgColors": 7,
+  "uniqueRadii": [
+    ["3.35544e+07px", 24],
+    ["6px", 9],
+    ["100%", 1],
+    ["0px 0px 0px 1px", 1],
+    ["0px 8px 8px 0px", 1],
+    ["3.35544e+07px 6px 6px 3.35544e+07px", 1]
+  ],
+  "uniqueShadows": [
+    [
+      "rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(255, 255, 255, 0.145) 0px 0px 0px 1px, rgb(0, 0, 0) 0px 0px 0px 1px",
+      5
+    ],
+    [
+      "rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgb(46, 46, 46) 0px 0px 0px 1px",
+      3
+    ],
+    [
+      "rgba(255, 255, 255, 0.145) 0px 0px 0px 1px, rgba(0, 0, 0, 0.16) 0px 1px 2px 0px, rgb(0, 0, 0) 0px 0px 0px 1px",
+      1
+    ]
+  ],
+  "uniqueTextColors": 9,
+  "visibleElements": 501
+}

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildCommand } from "./build";
+
+/**
+ * Cronwatch — the identity used in the A/B run: paper background, ink text,
+ * amber accent, 2px radius, hue-driven primary.
+ */
+const cronwatchBlock = {
+  bg: "#faf9f5",
+  bg_2: "#f1efe9",
+  ui: "#dcd9d0",
+  ui_2: "#c9c5ba",
+  ui_3: "#a8a396",
+  tx: "#1c1b17",
+  tx_2: "#5c584e",
+  tx_3: "#8a857a",
+  pr: "#c98a2b",
+  sc: "#3c3931",
+  ac_1: "#2f6f4f",
+  ac_2: "#8a6d3b",
+  ac_3: "#b4341f",
+};
+
+const cronwatchDarkBlock = {
+  bg: "#171613",
+  bg_2: "#201f1a",
+  ui: "#332f28",
+  ui_2: "#453f35",
+  ui_3: "#5c554a",
+  tx: "#f2f0ea",
+  tx_2: "#b3ada0",
+  tx_3: "#847e72",
+  pr: "#e0a94f",
+  sc: "#d9d4c8",
+  ac_1: "#5fae86",
+  ac_2: "#c4a05e",
+  ac_3: "#e0664f",
+};
+
+const cronwatchIdentity = {
+  name: "cronwatch",
+  theme: {
+    light: cronwatchBlock,
+    dark: cronwatchDarkBlock,
+    name: "Cronwatch",
+  },
+  typography: {
+    families: {
+      sans: "system-ui, sans-serif",
+      mono: "ui-monospace, monospace",
+    },
+    roles: {
+      display: { size: 44, lineHeight: 1.05, weight: 600 },
+      title: { size: 30, lineHeight: 1.15, weight: 600 },
+      heading: { size: 20, lineHeight: 1.3, weight: 600 },
+      body: { size: 16, lineHeight: 1.6, weight: 400 },
+      label: { size: 13, lineHeight: 1.4, weight: 500 },
+      mono: { size: 13, lineHeight: 1.5, weight: 400 },
+    },
+  },
+  radius: "2px",
+  primaryStyle: "hue",
+  voiceWords: ["operational", "exact", "unhurried"],
+  dosDonts: [
+    "Do: state the failure mode before the feature.",
+    'Don\'t: use the word "platform".',
+  ],
+};
+
+let workDir: string;
+
+async function writeConfig(name: string, config: unknown): Promise<string> {
+  const path = join(workDir, name);
+  await writeFile(path, JSON.stringify(config, null, 2), "utf8");
+  return path;
+}
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "tinte-build-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("buildCommand --plugin", () => {
+  it("emits a well-formed agent plugin for Cronwatch", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const out = join(workDir, "out");
+
+    const code = await buildCommand([
+      "--plugin",
+      "--config",
+      config,
+      "--out",
+      out,
+    ]);
+    expect(code).toBe(0);
+
+    const pluginJson = JSON.parse(
+      await readFile(join(out, "plugin.json"), "utf8"),
+    );
+    expect(pluginJson.$schema).toBe(
+      "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+    );
+    expect(pluginJson.name).toBe("cronwatch-design");
+
+    const skill = await readFile(
+      join(out, "skills", "cronwatch-design", "SKILL.md"),
+      "utf8",
+    );
+    expect(skill).not.toContain("{{");
+    expect(skill).not.toContain("}}");
+    expect(skill).toContain("cronwatch");
+    expect(skill).toContain("./references/tokens.css");
+    expect(skill).toContain("display 44/1.05 600");
+    expect(skill).toContain("operational, exact, unhurried");
+    expect(skill).toContain("Do: state the failure mode before the feature.");
+
+    // The rules block renders as bullets...
+    expect(skill).toContain(
+      "- Do: state the failure mode before the feature.\n",
+    );
+    // ...but the inline occurrence stays a sentence, not a broken list.
+    expect(skill).toContain(
+      'Sentence case unless\nDo: state the failure mode before the feature; Don\'t: use the word "platform" says otherwise.',
+    );
+    expect(skill).not.toContain(
+      '- Don\'t: use the word "platform". says otherwise.',
+    );
+
+    const tokens = await readFile(
+      join(out, "skills", "cronwatch-design", "references", "tokens.css"),
+      "utf8",
+    );
+    expect(tokens).toContain("oklch(");
+    expect(tokens).toContain("--radius: 2px;");
+    expect(tokens).toContain(":root {");
+    expect(tokens).toContain(".dark {");
+    expect(tokens).not.toContain("#");
+
+    // Every shadcn base token the template promises must be present.
+    for (const token of [
+      "background",
+      "foreground",
+      "card",
+      "card-foreground",
+      "popover",
+      "popover-foreground",
+      "primary",
+      "primary-foreground",
+      "secondary",
+      "secondary-foreground",
+      "muted",
+      "muted-foreground",
+      "accent",
+      "accent-foreground",
+      "destructive",
+      "destructive-foreground",
+      "border",
+      "input",
+      "ring",
+    ]) {
+      expect(tokens).toContain(`--${token}: oklch(`);
+    }
+
+    // Values are rounded, not raw float dumps.
+    for (const value of tokens.matchAll(/oklch\(([^)]*)\)/g)) {
+      for (const component of value[1].trim().split(/\s+/)) {
+        const decimals = component.split(".")[1];
+        expect(decimals === undefined || decimals.length <= 4).toBe(true);
+      }
+    }
+  });
+
+  it("does not inject the inverted note for primaryStyle hue", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const out = join(workDir, "out");
+
+    expect(
+      await buildCommand(["--plugin", "--config", config, "--out", out]),
+    ).toBe(0);
+
+    const skill = await readFile(
+      join(out, "skills", "cronwatch-design", "SKILL.md"),
+      "utf8",
+    );
+    expect(skill).not.toContain("inverted foreground/background pair");
+  });
+});
+
+describe("buildCommand primaryStyle inverted", () => {
+  it("injects the inverted-primary rule and inverts --primary", async () => {
+    const config = await writeConfig("inverted.json", {
+      ...cronwatchIdentity,
+      name: "monolith",
+      primaryStyle: "inverted",
+    });
+    const out = join(workDir, "out");
+
+    expect(
+      await buildCommand(["--plugin", "--config", config, "--out", out]),
+    ).toBe(0);
+
+    const skill = await readFile(
+      join(out, "skills", "monolith-design", "SKILL.md"),
+      "utf8",
+    );
+    expect(skill).not.toContain("{{");
+    expect(skill).toContain(
+      "The primary action style is an inverted foreground/background pair, not a hue.",
+    );
+    expect(skill).toContain("Do not introduce an accent color for CTAs.");
+
+    const tokens = await readFile(
+      join(out, "skills", "monolith-design", "references", "tokens.css"),
+      "utf8",
+    );
+    // --primary must equal --foreground (tx), not the amber accent.
+    const foreground = tokens.match(/--foreground: (oklch\([^)]*\));/)?.[1];
+    const primary = tokens.match(/--primary: (oklch\([^)]*\));/)?.[1];
+    expect(foreground).toBeDefined();
+    expect(primary).toBe(foreground as string);
+
+    const background = tokens.match(/--background: (oklch\([^)]*\));/)?.[1];
+    const primaryFg = tokens.match(
+      /--primary-foreground: (oklch\([^)]*\));/,
+    )?.[1];
+    expect(primaryFg).toBe(background as string);
+  });
+});
+
+describe("buildCommand without --plugin", () => {
+  it("emits design.md and tokens.css loose", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const out = join(workDir, "out");
+
+    expect(await buildCommand(["--config", config, "--out", out])).toBe(0);
+
+    const design = await readFile(join(out, "design.md"), "utf8");
+    expect(design).not.toContain("{{");
+    expect(design).toContain("cronwatch");
+
+    const tokens = await readFile(join(out, "tokens.css"), "utf8");
+    expect(tokens).toContain("oklch(");
+    expect(tokens).toContain("--radius: 2px;");
+  });
+
+  it("omits the .dark block when the theme has no dark variant", async () => {
+    const { dark: _dark, ...lightOnly } = cronwatchIdentity.theme;
+    const config = await writeConfig("light-only.json", {
+      ...cronwatchIdentity,
+      theme: lightOnly,
+    });
+    const out = join(workDir, "out");
+
+    expect(await buildCommand(["--config", config, "--out", out])).toBe(0);
+
+    const tokens = await readFile(join(out, "tokens.css"), "utf8");
+    expect(tokens).toContain(":root {");
+    expect(tokens).not.toContain(".dark {");
+  });
+});
+
+describe("buildCommand validation", () => {
+  it("exits non-zero with a clear error on an invalid config", async () => {
+    const config = await writeConfig("bad.json", {
+      ...cronwatchIdentity,
+      primaryStyle: "gradient",
+      radius: "",
+    });
+    const out = join(workDir, "out");
+
+    const errors: string[] = [];
+    const original = console.error;
+    console.error = (...parts: unknown[]) => {
+      errors.push(parts.map(String).join(" "));
+    };
+
+    let code: number;
+    try {
+      code = await buildCommand(["--plugin", "--config", config, "--out", out]);
+    } finally {
+      console.error = original;
+    }
+
+    expect(code).not.toBe(0);
+    const output = errors.join("\n");
+    expect(output).toContain("not a valid tinte identity");
+    expect(output).toContain("primaryStyle");
+    expect(output).toContain("radius");
+  });
+
+  it("exits non-zero when the config file is missing", async () => {
+    const original = console.error;
+    const errors: string[] = [];
+    console.error = (...parts: unknown[]) => {
+      errors.push(parts.map(String).join(" "));
+    };
+
+    let code: number;
+    try {
+      code = await buildCommand([
+        "--config",
+        join(workDir, "does-not-exist.json"),
+        "--out",
+        join(workDir, "out"),
+      ]);
+    } finally {
+      console.error = original;
+    }
+
+    expect(code).not.toBe(0);
+    expect(errors.join("\n")).toContain("config not found");
+  });
+
+  it("exits non-zero on malformed JSON", async () => {
+    const path = join(workDir, "broken.json");
+    await writeFile(path, "{ not json", "utf8");
+
+    const original = console.error;
+    const errors: string[] = [];
+    console.error = (...parts: unknown[]) => {
+      errors.push(parts.map(String).join(" "));
+    };
+
+    let code: number;
+    try {
+      code = await buildCommand([
+        "--config",
+        path,
+        "--out",
+        join(workDir, "o"),
+      ]);
+    } finally {
+      console.error = original;
+    }
+
+    expect(code).not.toBe(0);
+    expect(errors.join("\n")).toContain("not valid JSON");
+  });
+});

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,0 +1,389 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type TinteBlock,
+  type TinteIdentity,
+  TinteIdentitySchema,
+  type Typography,
+} from "@tinte/core";
+import { formatCss, oklch, parse } from "culori";
+
+const PLUGIN_SCHEMA_URL =
+  "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+
+const INVERTED_PRIMARY_NOTE =
+  "The primary action style is an inverted foreground/background pair, not a hue. Do not introduce an accent color for CTAs.";
+
+const TOKENS_CSS_URL = "./references/tokens.css";
+
+interface BuildOptions {
+  configPath: string;
+  outDir: string;
+  plugin: boolean;
+}
+
+/**
+ * `tinte build [--plugin] [--config <file>] [--out <dir>]`
+ *
+ * Reads a TinteIdentity config, validates it against the V4 schema, and emits
+ * either a full Agent Plugin directory (--plugin) or the two loose artifacts
+ * (design.md + tokens.css).
+ */
+export async function buildCommand(args: string[]): Promise<number> {
+  let options: BuildOptions;
+  try {
+    options = parseArgs(args);
+  } catch (error) {
+    console.error(`Error: ${messageOf(error)}`);
+    return 1;
+  }
+
+  const configPath = resolve(process.cwd(), options.configPath);
+  if (!existsSync(configPath)) {
+    console.error(`Error: config not found at ${configPath}`);
+    return 1;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(configPath, "utf8"));
+  } catch (error) {
+    console.error(
+      `Error: ${configPath} is not valid JSON. ${messageOf(error)}`,
+    );
+    return 1;
+  }
+
+  const parsed = TinteIdentitySchema.safeParse(raw);
+  if (!parsed.success) {
+    console.error(`Error: ${configPath} is not a valid tinte identity.`);
+    for (const issue of parsed.error.issues) {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+      console.error(`  ${path}: ${issue.message}`);
+    }
+    return 1;
+  }
+
+  const identity = parsed.data;
+  const outDir = resolve(
+    process.cwd(),
+    options.outDir ?? `./${identity.name}-plugin`,
+  );
+
+  let template: string;
+  try {
+    template = await loadTemplate();
+  } catch (error) {
+    console.error(`Error: ${messageOf(error)}`);
+    return 1;
+  }
+
+  const skillMarkdown = renderSkill(template, identity);
+  const tokensCss = renderTokensCss(identity);
+
+  const written: string[] = [];
+
+  if (options.plugin) {
+    const skillName = `${identity.name}-design`;
+    const skillDir = join(outDir, "skills", skillName);
+    const referencesDir = join(skillDir, "references");
+
+    await mkdir(referencesDir, { recursive: true });
+
+    const pluginJson = `${JSON.stringify(
+      { $schema: PLUGIN_SCHEMA_URL, name: skillName },
+      null,
+      2,
+    )}\n`;
+
+    written.push(await write(join(outDir, "plugin.json"), pluginJson));
+    written.push(await write(join(skillDir, "SKILL.md"), skillMarkdown));
+    written.push(await write(join(referencesDir, "tokens.css"), tokensCss));
+  } else {
+    await mkdir(outDir, { recursive: true });
+    written.push(await write(join(outDir, "design.md"), skillMarkdown));
+    written.push(await write(join(outDir, "tokens.css"), tokensCss));
+  }
+
+  for (const file of written) {
+    console.log(file);
+  }
+
+  return 0;
+}
+
+function parseArgs(args: string[]): BuildOptions {
+  let configPath = "./tinte.config.json";
+  let outDir = "";
+  let plugin = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--plugin") {
+      plugin = true;
+    } else if (arg === "--config" || arg === "--out") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      if (arg === "--config") configPath = value;
+      else outDir = value;
+      i++;
+    } else if (arg.startsWith("--config=")) {
+      configPath = arg.slice("--config=".length);
+    } else if (arg.startsWith("--out=")) {
+      outDir = arg.slice("--out=".length);
+    } else {
+      throw new Error(`unknown argument "${arg}"`);
+    }
+  }
+
+  return { configPath, outDir, plugin };
+}
+
+/**
+ * Resolve assets/templates/landing.md relative to this module so the command
+ * works from src (bun test, tsx) and from the bundled dist/ output, where the
+ * bundle sits one level deeper than the package root.
+ */
+async function loadTemplate(): Promise<string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // src/commands/build.ts -> packages/cli/assets
+    resolve(here, "../../assets/templates/landing.md"),
+    // dist/cli.js -> packages/cli/assets
+    resolve(here, "../assets/templates/landing.md"),
+    resolve(here, "assets/templates/landing.md"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return readFile(candidate, "utf8");
+    }
+  }
+
+  throw new Error(
+    `landing template not found. Looked in:\n  ${candidates.join("\n  ")}`,
+  );
+}
+
+function renderSkill(template: string, identity: TinteIdentity): string {
+  const slots: Record<string, string> = {
+    brand_name: identity.name,
+    tokens_css_url: identity.tokensCssUrl ?? TOKENS_CSS_URL,
+    type_scale: renderTypeScale(identity.typography),
+    voice_words: renderVoiceWords(identity.voiceWords),
+    brand_dos_donts: renderDosDonts(identity.dosDonts),
+  };
+
+  // The template uses {{brand_dos_donts}} twice in different grammatical
+  // contexts: once inline mid-sentence ("… unless {{slot}} says otherwise.")
+  // and once as a standalone rules block. A bulleted list is right for the
+  // block and wrong for the sentence, so the inline occurrence is resolved
+  // first, against its surrounding prose.
+  let output = template.replaceAll(
+    "{{brand_dos_donts}} says otherwise.",
+    `${renderDosDontsInline(identity.dosDonts)} says otherwise.`,
+  );
+
+  for (const [slot, value] of Object.entries(slots)) {
+    output = output.replaceAll(`{{${slot}}}`, value);
+  }
+
+  if (identity.primaryStyle === "inverted") {
+    output = injectInvertedNote(output);
+  }
+
+  return output;
+}
+
+/**
+ * Append the inverted-primary rule to the "Token foundation" section, right
+ * before the section that follows it.
+ */
+function injectInvertedNote(markdown: string): string {
+  const heading = "### Token foundation";
+  const start = markdown.indexOf(heading);
+  if (start === -1) {
+    return `${markdown.trimEnd()}\n\n${INVERTED_PRIMARY_NOTE}\n`;
+  }
+
+  const nextHeading = markdown.indexOf("\n### ", start + heading.length);
+  const insertAt = nextHeading === -1 ? markdown.length : nextHeading;
+
+  const before = markdown.slice(0, insertAt).trimEnd();
+  const after = markdown.slice(insertAt);
+
+  return `${before}\n\n${INVERTED_PRIMARY_NOTE}\n${after}`;
+}
+
+function renderTypeScale(typography: Typography): string {
+  const roles = typography.roles;
+  const parts = (
+    ["display", "title", "heading", "body", "label", "mono"] as const
+  ).map((name) => {
+    const role = roles[name];
+    return `${name} ${role.size}/${role.lineHeight} ${role.weight}`;
+  });
+
+  return `Six roles only: ${parts.join(" · ")}. Sans: ${
+    typography.families.sans
+  }. Mono: ${typography.families.mono}. No other sizes or weights exist.`;
+}
+
+function renderVoiceWords(words?: string[]): string {
+  if (!words || words.length === 0) {
+    return "plain, concrete, specific";
+  }
+  return words.join(", ");
+}
+
+function renderDosDonts(rules?: string[]): string {
+  if (!rules || rules.length === 0) {
+    return "No brand-specific overrides. The archetype defaults stand alone.";
+  }
+  return rules.map((rule) => `- ${rule}`).join("\n");
+}
+
+/**
+ * Same rules, flattened into one clause so the sentence that embeds them stays
+ * a sentence.
+ */
+function renderDosDontsInline(rules?: string[]): string {
+  if (!rules || rules.length === 0) {
+    return "a brand rule";
+  }
+  return rules.map((rule) => rule.replace(/\.$/, "")).join("; ");
+}
+
+/**
+ * TinteBlock (13 tokens) -> shadcn CSS variables.
+ *
+ * Mapping rationale — the theme graph is a semantic 13-token model, shadcn is a
+ * role-based surface API, so several shadcn roles legitimately share one source
+ * token:
+ *
+ *   bg    -> background            the page canvas
+ *   tx    -> foreground            body text on the canvas
+ *   bg_2  -> card, popover,        every raised/recessed surface one step off
+ *            secondary, muted      the canvas; the graph has a single such step
+ *   tx    -> card-foreground,      text on those surfaces is the same ink; the
+ *            popover-foreground    graph does not model per-surface ink
+ *   tx_2  -> muted-foreground      the muted/secondary text tier
+ *   sc    -> secondary-foreground  falls back to tx when sc is missing
+ *   ui    -> border, input         the resting border tier (ui_2/ui_3 are the
+ *                                  hover/active tiers, which shadcn does not
+ *                                  express as base tokens)
+ *   pr    -> primary, ring, accent one accent owns the primary action, its
+ *                                  focus ring, and the accent surface
+ *   ac_3  -> destructive           the graph's third accent is the alert slot
+ *
+ * primaryStyle "inverted": the CTA is a foreground/background inversion rather
+ * than a hue, so --primary becomes tx and --primary-foreground becomes bg. ring
+ * follows primary; accent stays on pr so a non-CTA accent surface remains
+ * available.
+ */
+function mapBlockToShadcn(
+  block: TinteBlock,
+  primaryStyle: TinteIdentity["primaryStyle"],
+): Array<[string, string]> {
+  const inverted = primaryStyle === "inverted";
+
+  const primary = inverted ? block.tx : block.pr;
+  const primaryForeground = inverted ? block.bg : bestContrast(block.pr, block);
+
+  return [
+    ["background", block.bg],
+    ["foreground", block.tx],
+    ["card", block.bg_2],
+    ["card-foreground", block.tx],
+    ["popover", block.bg_2],
+    ["popover-foreground", block.tx],
+    ["primary", primary],
+    ["primary-foreground", primaryForeground],
+    ["secondary", block.bg_2],
+    ["secondary-foreground", block.sc || block.tx],
+    ["muted", block.bg_2],
+    ["muted-foreground", block.tx_2],
+    ["accent", block.pr],
+    ["accent-foreground", bestContrast(block.pr, block)],
+    ["destructive", block.ac_3],
+    ["destructive-foreground", bestContrast(block.ac_3, block)],
+    ["border", block.ui],
+    ["input", block.ui],
+    ["ring", primary],
+  ];
+}
+
+/**
+ * Pick bg or tx as the readable ink over `color`, by OKLCH lightness. The graph
+ * gives no explicit on-accent ink, so this is a deterministic approximation.
+ * The 0.7 threshold keeps mid-lightness accents (an amber at L≈0.68) on the
+ * light ink, which is what a designer picks for a saturated CTA fill.
+ */
+const INK_FLIP_LIGHTNESS = 0.7;
+
+function bestContrast(color: string, block: TinteBlock): string {
+  const parsed = oklch(parse(color));
+  if (!parsed) return block.tx;
+  return parsed.l > INK_FLIP_LIGHTNESS ? block.tx : block.bg;
+}
+
+/**
+ * culori's formatCss emits full float precision, which makes the token file
+ * unreadable and churns diffs. Round to 4 decimals, matching the format the
+ * shadcn provider already emits.
+ */
+function toOklch(color: string): string {
+  const parsed = oklch(parse(color));
+  if (!parsed) return color;
+  const round = (n: number) => Number.parseFloat(n.toFixed(4));
+  return formatCss({
+    mode: "oklch",
+    l: round(parsed.l),
+    c: round(parsed.c),
+    h: round(parsed.h ?? 0),
+    alpha: parsed.alpha,
+  });
+}
+
+function renderTokensCss(identity: TinteIdentity): string {
+  const { theme, radius, primaryStyle, name } = identity;
+
+  const block = (
+    entries: Array<[string, string]>,
+    selector: string,
+    withRadius: boolean,
+  ): string => {
+    const lines = entries.map(
+      ([token, value]) => `  --${token}: ${toOklch(value)};`,
+    );
+    if (withRadius) lines.push(`  --radius: ${radius};`);
+    return `${selector} {\n${lines.join("\n")}\n}`;
+  };
+
+  const parts = [
+    `/* ${name} design tokens — public API. Do not read implementation into context. */`,
+    block(mapBlockToShadcn(theme.light, primaryStyle), ":root", true),
+  ];
+
+  if (theme.dark) {
+    parts.push(
+      block(mapBlockToShadcn(theme.dark, primaryStyle), ".dark", false),
+    );
+  }
+
+  return `${parts.join("\n\n")}\n`;
+}
+
+async function write(path: string, contents: string): Promise<string> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, "utf8");
+  return path;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/cli/src/commands/from.test.ts
+++ b/packages/cli/src/commands/from.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { oklch } from "culori";
+import { fromCommand } from "./from";
+
+const FIXTURE_PATH = join(
+  import.meta.dir,
+  "__fixtures__",
+  "vercel-candidates.json",
+);
+const OUT_PATH = join(
+  import.meta.dir,
+  "__fixtures__",
+  "vercel-identity.out.json",
+);
+
+function captureStdout(fn: () => Promise<number>): Promise<{
+  exitCode: number;
+  lines: string[];
+}> {
+  const originalLog = console.log;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  return fn()
+    .then((exitCode) => ({ exitCode, lines }))
+    .finally(() => {
+      console.log = originalLog;
+    });
+}
+
+function silenceStderr<T>(fn: () => T): T {
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    return fn();
+  } finally {
+    console.error = originalError;
+  }
+}
+
+afterAll(() => {
+  if (existsSync(OUT_PATH)) unlinkSync(OUT_PATH);
+});
+
+describe("tinte from --emit-script", () => {
+  test("prints extract.js to stdout", async () => {
+    const { exitCode, lines } = await captureStdout(() =>
+      fromCommand(["--emit-script"]),
+    );
+    expect(exitCode).toBe(0);
+    const script = lines.join("\n");
+    expect(script).toContain("extract");
+    expect(script.length).toBeGreaterThan(100);
+  });
+});
+
+describe("tinte from --normalize", () => {
+  test("produces valid identity JSON with correct bg/fg for vercel", async () => {
+    const { exitCode, lines } = await silenceStderr(() =>
+      captureStdout(() =>
+        fromCommand(["--normalize", FIXTURE_PATH, "--name", "vercel"]),
+      ),
+    );
+
+    expect(exitCode).toBe(0);
+
+    const output = JSON.parse(lines.join("\n"));
+
+    expect(output.name).toBe("vercel");
+    expect(output.theme.light.bg).toBeDefined();
+    expect(output.theme.light.tx).toBeDefined();
+
+    const bgOklch = oklch(output.theme.light.bg as string);
+    const fgOklch = oklch(output.theme.light.tx as string);
+
+    expect(bgOklch).not.toBeNull();
+    expect(fgOklch).not.toBeNull();
+
+    // vercel: bg near-black, fg near-white
+    expect(bgOklch?.l ?? 1).toBeLessThan(0.2);
+    expect(fgOklch?.l ?? 0).toBeGreaterThan(0.8);
+  });
+
+  test("detects primaryStyle 'inverted' for vercel (no recurring saturated hue)", async () => {
+    const { lines } = await silenceStderr(() =>
+      captureStdout(() =>
+        fromCommand(["--normalize", FIXTURE_PATH, "--name", "vercel"]),
+      ),
+    );
+    const output = JSON.parse(lines.join("\n"));
+    expect(output.primaryStyle).toBe("inverted");
+  });
+
+  test("normalizes pill/full radii (3.35544e+07px -> full)", async () => {
+    const { lines } = await silenceStderr(() =>
+      captureStdout(() =>
+        fromCommand(["--normalize", FIXTURE_PATH, "--name", "vercel"]),
+      ),
+    );
+    const output = JSON.parse(lines.join("\n"));
+    expect(output.radius).toBe("full");
+  });
+
+  test("colors are emitted in oklch() format", async () => {
+    const { lines } = await silenceStderr(() =>
+      captureStdout(() =>
+        fromCommand(["--normalize", FIXTURE_PATH, "--name", "vercel"]),
+      ),
+    );
+    const output = JSON.parse(lines.join("\n"));
+    expect(output.theme.light.bg).toMatch(/^oklch\(/);
+    expect(output.theme.light.tx).toMatch(/^oklch\(/);
+  });
+
+  test("writes to --out file when provided", async () => {
+    await silenceStderr(() =>
+      fromCommand([
+        "--normalize",
+        FIXTURE_PATH,
+        "--name",
+        "vercel",
+        "--out",
+        OUT_PATH,
+      ]),
+    );
+    expect(existsSync(OUT_PATH)).toBe(true);
+    const written = JSON.parse(readFileSync(OUT_PATH, "utf-8"));
+    expect(written.name).toBe("vercel");
+  });
+
+  test("exits 2 with usage error when no mode flag given", async () => {
+    const { exitCode } = await silenceStderr(() =>
+      captureStdout(() => fromCommand([])),
+    );
+    expect(exitCode).toBe(2);
+  });
+
+  test("exits 2 when --normalize is missing the candidates path", async () => {
+    const { exitCode } = await silenceStderr(() =>
+      captureStdout(() => fromCommand(["--normalize"])),
+    );
+    expect(exitCode).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/from.ts
+++ b/packages/cli/src/commands/from.ts
@@ -1,0 +1,365 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { oklch } from "culori";
+import { z } from "zod";
+
+// TODO-wire: import { TinteIdentitySchema } from "@tinte/core" once V4 lands
+// (packages/core/src/types/identity.ts). Until then this is a local mirror
+// of the shape described in slices.md V4, kept in sync by hand. DEVIATION:
+// documented in the from-command report, not silently assumed.
+const TypeRoleSchema = z.object({
+  size: z.number(),
+  lineHeight: z.number(),
+  weight: z.number(),
+});
+
+const TinteIdentitySchema = z.object({
+  name: z.string(),
+  theme: z
+    .object({
+      light: z.record(z.string(), z.string()),
+      dark: z.record(z.string(), z.string()).optional(),
+    })
+    .partial({ dark: true }),
+  typography: z.object({
+    families: z.object({
+      sans: z.string(),
+      mono: z.string(),
+    }),
+    roles: z.object({
+      display: TypeRoleSchema.optional(),
+      title: TypeRoleSchema.optional(),
+      heading: TypeRoleSchema.optional(),
+      body: TypeRoleSchema.optional(),
+      label: TypeRoleSchema.optional(),
+      mono: TypeRoleSchema.optional(),
+    }),
+  }),
+  radius: z.string(),
+  primaryStyle: z.enum(["hue", "inverted"]),
+  voiceWords: z.array(z.string()).optional(),
+  dosDonts: z.array(z.string()).optional(),
+  tokensCssUrl: z.string().optional(),
+});
+
+type TinteIdentity = z.infer<typeof TinteIdentitySchema>;
+
+interface ColorCandidate {
+  color: string;
+  area: number;
+  count: number;
+}
+
+interface RawCandidates {
+  fontFamilies: string[];
+  fontSizesSorted: Array<{ size: string; count: number }>;
+  fontWeights: string[];
+  lineHeights: string[];
+  styleSheets: Array<{
+    href: string;
+    ok: boolean;
+    ruleCount?: number;
+    error?: string;
+  }>;
+  topBgColorsByArea: ColorCandidate[];
+  topTextColorsByArea: ColorCandidate[];
+  totalElements: number;
+  uniqueBgColors: number;
+  uniqueRadii: Array<[string, number]>;
+  uniqueShadows: Array<[string, number]>;
+  uniqueTextColors: number;
+  visibleElements: number;
+}
+
+const FULL_RADIUS_THRESHOLD_PX = 9000;
+const OKLCH_CHROMA_SATURATED_THRESHOLD = 0.09;
+const TOP_N_PER_CHANNEL = 10;
+
+function resolveExtractScriptPath(): string {
+  // Works under `tsx` dev (ESM, import.meta.url available) and under the
+  // tsup CJS build (import.meta.url is polyfilled to a file:// URL by
+  // esbuild's cjs interop for `target: node16`, __dirname is also valid
+  // there). Try import.meta first, fall back to __dirname for safety.
+  let dir: string;
+  try {
+    dir = dirname(fileURLToPath(import.meta.url));
+  } catch {
+    // biome-ignore lint/suspicious/noExplicitAny: __dirname is CJS-only
+    dir = (globalThis as any).__dirname ?? process.cwd();
+  }
+
+  const candidates = [
+    // dev via tsx: dir = packages/cli/src/commands
+    join(dir, "..", "..", "assets", "extract.js"),
+    // built via tsup (cjs bundle at packages/cli/dist/cli.js): dir = dist
+    join(dir, "..", "assets", "extract.js"),
+    join(dir, "assets", "extract.js"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  throw new Error(
+    `tinte from: could not locate extract.js from ${dir} (tried ${candidates.join(", ")})`,
+  );
+}
+
+function normalizeRadius(raw: string): string {
+  const trimmed = raw.trim();
+  const numeric = Number.parseFloat(trimmed);
+  if (!Number.isNaN(numeric) && numeric >= FULL_RADIUS_THRESHOLD_PX) {
+    return "full";
+  }
+  // Mixed pill shorthand like "3.35544e+07px 6px 6px 3.35544e+07px"
+  if (/e\+0?[7-9]/i.test(trimmed)) {
+    return "full";
+  }
+  if (trimmed === "100%") return "full";
+  return trimmed;
+}
+
+const AREA_HIGH_THRESHOLD = 100_000;
+
+function isDecorative(candidate: ColorCandidate): boolean {
+  // High-area, count==1 = painted once, large surface - a decorative
+  // gradient/hero background, not a recurring system token. Low-area
+  // count==1 is just noise, not decorative; leave it to the area sort
+  // to drop it naturally.
+  return candidate.count === 1 && candidate.area >= AREA_HIGH_THRESHOLD;
+}
+
+function topCandidates(
+  candidates: ColorCandidate[],
+  n: number,
+): ColorCandidate[] {
+  // Area is the primary signal (what dominates the canvas); count is the
+  // tie-breaker (what recurs as a system token). Decorative area-high
+  // count-1 entries (hero gradients) are dropped before ranking.
+  return candidates
+    .filter((c) => !isDecorative(c))
+    .sort((a, b) => {
+      if (b.area !== a.area) return b.area - a.area;
+      return b.count - a.count;
+    })
+    .slice(0, n);
+}
+
+function toOklchString(cssColor: string): string | null {
+  const parsed = oklch(cssColor);
+  if (!parsed) return null;
+  const l = Number.isFinite(parsed.l) ? parsed.l : 0;
+  const c = Number.isFinite(parsed.c) ? parsed.c : 0;
+  const h = Number.isFinite(parsed.h) ? (parsed.h as number) : 0;
+  return `oklch(${l.toFixed(4)} ${c.toFixed(4)} ${h.toFixed(2)})`;
+}
+
+function chroma(cssColor: string): number {
+  const parsed = oklch(cssColor);
+  return parsed?.c ?? 0;
+}
+
+function isSaturated(candidate: ColorCandidate): boolean {
+  return chroma(candidate.color) > OKLCH_CHROMA_SATURATED_THRESHOLD;
+}
+
+const PRIMARY_HUE_MIN_RANK = 3;
+
+function detectPrimaryStyle(
+  bgTop: ColorCandidate[],
+  textTop: ColorCandidate[],
+): "hue" | "inverted" {
+  // "hue" wins only if a saturated color ranks among the top area-dominant
+  // candidates (a real recurring surface, e.g. a CTA button fill) - not
+  // just any saturated color that shows up anywhere in the top-10 (a
+  // small success/error badge chroma is noise, not a primary). Otherwise
+  // the site's CTA is an inverted fg/bg pair (linear.app/vercel.com
+  // pattern from the spike).
+  const rankedTop = [...bgTop, ...textTop]
+    .slice(0, PRIMARY_HUE_MIN_RANK * 2)
+    .filter((c) => c.count > 1);
+  const saturatedRecurring = rankedTop.find((c) => isSaturated(c));
+  return saturatedRecurring ? "hue" : "inverted";
+}
+
+function pickFamilies(fontFamilies: string[]): { sans: string; mono: string } {
+  const mono =
+    fontFamilies.find((f) => /mono/i.test(f)) ?? "ui-monospace, monospace";
+  const sans =
+    fontFamilies.find((f) => f !== mono) ?? fontFamilies[0] ?? "sans-serif";
+  return { sans, mono };
+}
+
+function normalize(
+  raw: RawCandidates,
+  name: string,
+): {
+  identity: Partial<TinteIdentity>;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+
+  const bgTop = topCandidates(raw.topBgColorsByArea, TOP_N_PER_CHANNEL);
+  const textTop = topCandidates(raw.topTextColorsByArea, TOP_N_PER_CHANNEL);
+
+  if (bgTop.length === 0) {
+    warnings.push(
+      "no usable bg candidates after filtering decorative area-1 entries",
+    );
+  }
+  if (textTop.length === 0) {
+    warnings.push(
+      "no usable text candidates after filtering decorative area-1 entries",
+    );
+  }
+
+  // bg = highest-area recurring background; fg = highest-area recurring text.
+  const bgCandidate = bgTop[0];
+  const fgCandidate = textTop[0];
+
+  const bg = bgCandidate ? toOklchString(bgCandidate.color) : null;
+  const fg = fgCandidate ? toOklchString(fgCandidate.color) : null;
+
+  if (!bg)
+    warnings.push("bg: could not derive - no dominant background color found");
+  if (!fg) warnings.push("fg: could not derive - no dominant text color found");
+
+  for (const token of ["destructive", "ring", "input"]) {
+    warnings.push(
+      `${token}: not derivable from homepage-only capture - requires crawling form/focus states`,
+    );
+  }
+
+  const primaryStyle = detectPrimaryStyle(bgTop, textTop);
+
+  const radiusEntries = raw.uniqueRadii
+    .map(([r, count]) => ({ radius: normalizeRadius(r), count }))
+    .filter((r) => /^\d/.test(r.radius) || r.radius === "full");
+  const radiusWinner = radiusEntries.sort((a, b) => b.count - a.count)[0];
+  const radius = radiusWinner?.radius ?? "0px";
+
+  const { sans, mono } = pickFamilies(raw.fontFamilies);
+
+  const sortedSizes = raw.fontSizesSorted
+    .filter((s) => Number.parseFloat(s.size) > 0)
+    .sort((a, b) => Number.parseFloat(a.size) - Number.parseFloat(b.size));
+
+  const weightsSorted = raw.fontWeights
+    .map((w) => Number.parseFloat(w))
+    .filter((w) => !Number.isNaN(w))
+    .sort((a, b) => a - b);
+
+  function sizeAt(fromEnd: number): number {
+    const idx = sortedSizes.length - 1 - fromEnd;
+    const entry =
+      sortedSizes[Math.max(0, Math.min(idx, sortedSizes.length - 1))];
+    return entry ? Number.parseFloat(entry.size) : 16;
+  }
+
+  const bodySize = sortedSizes.find(
+    (s) => s.count === Math.max(...sortedSizes.map((x) => x.count)),
+  )?.size;
+  const bodySizeNum = bodySize ? Number.parseFloat(bodySize) : 16;
+  const maxWeight = weightsSorted[weightsSorted.length - 1] ?? 500;
+  const minWeight = weightsSorted[0] ?? 400;
+
+  const identity: Partial<TinteIdentity> = {
+    name,
+    theme: {
+      light: {
+        ...(bg ? { bg } : {}),
+        ...(fg ? { tx: fg } : {}),
+      },
+    },
+    typography: {
+      families: { sans, mono },
+      roles: {
+        display: {
+          size: sizeAt(0),
+          lineHeight: sizeAt(0) * 1.1,
+          weight: maxWeight,
+        },
+        body: {
+          size: bodySizeNum,
+          lineHeight: bodySizeNum * 1.5,
+          weight: minWeight,
+        },
+      },
+    },
+    radius,
+    primaryStyle,
+  };
+
+  return { identity, warnings };
+}
+
+function parseFlagValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  return args[idx + 1];
+}
+
+export async function fromCommand(args: string[]): Promise<number> {
+  if (args.includes("--emit-script")) {
+    const scriptPath = resolveExtractScriptPath();
+    const script = readFileSync(scriptPath, "utf-8");
+    console.log(script);
+    return 0;
+  }
+
+  const normalizeIdx = args.indexOf("--normalize");
+  if (normalizeIdx !== -1) {
+    const candidatesPath = args[normalizeIdx + 1];
+    if (!candidatesPath) {
+      console.error(
+        "tinte from: --normalize requires a <candidates.json> path",
+      );
+      return 2;
+    }
+
+    let raw: RawCandidates;
+    try {
+      raw = JSON.parse(readFileSync(candidatesPath, "utf-8"));
+    } catch (error) {
+      console.error(
+        `tinte from: could not read/parse ${candidatesPath} - ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return 2;
+    }
+
+    const name = parseFlagValue(args, "--name") ?? "untitled";
+    const outPath = parseFlagValue(args, "--out");
+
+    const { identity, warnings } = normalize(raw, name);
+
+    for (const warning of warnings) {
+      console.error(`tinte from: warning - ${warning}`);
+    }
+
+    let parsed: TinteIdentity;
+    try {
+      parsed = TinteIdentitySchema.parse(identity);
+    } catch (error) {
+      console.error(
+        `tinte from: normalized output failed schema validation - ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return 1;
+    }
+
+    const output = JSON.stringify(parsed, null, 2);
+
+    if (outPath) {
+      writeFileSync(outPath, output);
+    } else {
+      console.log(output);
+    }
+
+    return 0;
+  }
+
+  console.error(
+    "tinte from: usage - tinte from --emit-script | tinte from --normalize <candidates.json> [--name <n>] [--out <file>]",
+  );
+  return 2;
+}

--- a/packages/cli/src/commands/from.ts
+++ b/packages/cli/src/commands/from.ts
@@ -4,10 +4,10 @@ import { fileURLToPath } from "node:url";
 import { oklch } from "culori";
 import { z } from "zod";
 
-// TODO-wire: import { TinteIdentitySchema } from "@tinte/core" once V4 lands
-// (packages/core/src/types/identity.ts). Until then this is a local mirror
-// of the shape described in slices.md V4, kept in sync by hand. DEVIATION:
-// documented in the from-command report, not silently assumed.
+// Intentionally a LOOSE draft schema, not the strict TinteIdentitySchema from
+// @tinte/core: extraction from a homepage cannot derive every token (destructive,
+// ring, input need app states). `tinte from` emits a draft identity; `tinte build`
+// is the strict gate that validates the final config against the core schema.
 const TypeRoleSchema = z.object({
   size: z.number(),
   lineHeight: z.number(),

--- a/packages/cli/src/commands/lint.test.ts
+++ b/packages/cli/src/commands/lint.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { lintCommand } from "./lint";
+
+let dir: string;
+let logs: string[];
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tinte-lint-"));
+  logs = [];
+  originalLog = console.log;
+  originalError = console.error;
+  console.log = (...parts: unknown[]) => {
+    logs.push(parts.map(String).join(" "));
+  };
+  console.error = (...parts: unknown[]) => {
+    logs.push(parts.map(String).join(" "));
+  };
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("lintCommand", () => {
+  it("detects hex literals and tailwind palette classes with exact count", async () => {
+    const file = join(dir, "component.tsx");
+    writeFileSync(
+      file,
+      [
+        'const color = "#ff0000";',
+        'const short = "#f00";',
+        '<div className="bg-slate-500 text-red-200 border-blue-700">',
+        "</div>",
+      ].join("\n"),
+    );
+
+    const exitCode = await lintCommand([dir, "--json"]);
+
+    expect(exitCode).toBe(1);
+    const json = JSON.parse(logs.join("\n"));
+    expect(json.count).toBe(5);
+    const kinds = json.violations.map((v: { kind: string }) => v.kind).sort();
+    expect(kinds).toEqual([
+      "hex",
+      "hex",
+      "tailwind-palette",
+      "tailwind-palette",
+      "tailwind-palette",
+    ]);
+  });
+
+  it("returns 0 violations for a clean file using var(--token)", async () => {
+    const file = join(dir, "clean.tsx");
+    writeFileSync(
+      file,
+      [
+        "const style = {",
+        "  background: 'var(--background)',",
+        "  color: 'var(--foreground)',",
+        "};",
+      ].join("\n"),
+    );
+
+    const exitCode = await lintCommand([dir, "--json"]);
+
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(logs.join("\n"));
+    expect(json.count).toBe(0);
+    expect(json.violations).toEqual([]);
+  });
+
+  it("ignores tokens.css even when it contains hex literals", async () => {
+    const file = join(dir, "tokens.css");
+    writeFileSync(
+      file,
+      [
+        ":root {",
+        "  --background: #ffffff;",
+        "  --foreground: #0a0a0a;",
+        "}",
+      ].join("\n"),
+    );
+
+    const exitCode = await lintCommand([dir, "--json"]);
+
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(logs.join("\n"));
+    expect(json.count).toBe(0);
+  });
+
+  it("ignores lines with a tinte-ignore comment", async () => {
+    const file = join(dir, "legacy.tsx");
+    writeFileSync(
+      file,
+      [
+        'const brand = "#123456"; // tinte-ignore',
+        'const other = "#654321";',
+      ].join("\n"),
+    );
+
+    const exitCode = await lintCommand([dir, "--json"]);
+
+    expect(exitCode).toBe(1);
+    const json = JSON.parse(logs.join("\n"));
+    expect(json.count).toBe(1);
+    expect(json.violations[0].match).toBe("#654321");
+    expect(json.violations[0].line).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,0 +1,171 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+
+type ViolationKind = "hex" | "rgb-hsl" | "tailwind-palette";
+
+interface Violation {
+  file: string;
+  line: number;
+  kind: ViolationKind;
+  match: string;
+}
+
+const SCAN_EXTENSIONS = new Set([
+  ".tsx",
+  ".ts",
+  ".jsx",
+  ".js",
+  ".css",
+  ".html",
+]);
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git", ".next"]);
+
+const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
+const RGB_HSL_RE = /\b(?:rgb|rgba|hsl|hsla)\(/g;
+const TAILWIND_PALETTE_RE =
+  /\b(?:bg|text|border|from|to|via)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]+\b/g;
+
+const IGNORE_MARKER = "tinte-ignore";
+
+function isTokensCssFile(filePath: string): boolean {
+  return filePath.split(/[\\/]/).pop() === "tokens.css";
+}
+
+function collectFiles(root: string): string[] {
+  const results: string[] = [];
+
+  const stat = statSync(root);
+  if (stat.isFile()) {
+    if (SCAN_EXTENSIONS.has(extname(root))) {
+      results.push(root);
+    }
+    return results;
+  }
+
+  const walk = (dir: string) => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry)) continue;
+      const fullPath = join(dir, entry);
+      let entryStat: ReturnType<typeof statSync>;
+      try {
+        entryStat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (entryStat.isDirectory()) {
+        walk(fullPath);
+      } else if (entryStat.isFile() && SCAN_EXTENSIONS.has(extname(fullPath))) {
+        results.push(fullPath);
+      }
+    }
+  };
+
+  walk(root);
+  return results;
+}
+
+function scanFile(filePath: string): Violation[] {
+  if (isTokensCssFile(filePath)) return [];
+
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const violations: Violation[] = [];
+
+  lines.forEach((line, index) => {
+    if (line.includes(IGNORE_MARKER)) return;
+
+    for (const match of line.matchAll(HEX_RE)) {
+      violations.push({
+        file: filePath,
+        line: index + 1,
+        kind: "hex",
+        match: match[0],
+      });
+    }
+
+    for (const match of line.matchAll(RGB_HSL_RE)) {
+      violations.push({
+        file: filePath,
+        line: index + 1,
+        kind: "rgb-hsl",
+        match: match[0],
+      });
+    }
+
+    for (const match of line.matchAll(TAILWIND_PALETTE_RE)) {
+      violations.push({
+        file: filePath,
+        line: index + 1,
+        kind: "tailwind-palette",
+        match: match[0],
+      });
+    }
+  });
+
+  return violations;
+}
+
+export async function lintCommand(args: string[]): Promise<number> {
+  const jsonOutput = args.includes("--json");
+  const paths = args.filter((arg) => !arg.startsWith("--"));
+  const targets = paths.length > 0 ? paths : ["."];
+
+  let files: string[];
+  try {
+    files = targets.flatMap((target) => collectFiles(target));
+  } catch (error) {
+    console.error(
+      `tinte lint: error reading path — ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 2;
+  }
+
+  const violations = files.flatMap((file) => scanFile(file));
+
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        {
+          violations: violations.map((v) => ({
+            file: v.file,
+            line: v.line,
+            kind: v.kind,
+            match: v.match,
+          })),
+          count: violations.length,
+        },
+        null,
+        2,
+      ),
+    );
+    return violations.length > 0 ? 1 : 0;
+  }
+
+  if (violations.length === 0) {
+    console.log("tinte lint: clean — no hardcoded colors found");
+    return 0;
+  }
+
+  for (const violation of violations) {
+    const displayPath =
+      relative(process.cwd(), violation.file) || violation.file;
+    console.log(
+      `${displayPath}:${violation.line}  ${violation.kind}  ${violation.match}`,
+    );
+  }
+
+  console.log(
+    `\n${violations.length} violation${violations.length === 1 ? "" : "s"} found`,
+  );
+
+  return 1;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,15 +1,17 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "CommonJS",
-    "lib": ["ES2020"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": [
+      "ES2022"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "declaration": true,
@@ -19,8 +21,16 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "types": [
+      "bun-types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./colors/index";
 export * from "./types/code-template";
 export * from "./types/codex";
 export * from "./types/fonts";
+export * from "./types/identity";
 export * from "./types/overrides";
 export * from "./types/shadcn";
 export * from "./types/shiki";

--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { TinteBlockSchema } from "./tinte";
+
+/**
+ * Zod schema for TinteTheme. `tinte.ts` only exports the TinteTheme *type*
+ * (the providers depend on it), so the runtime schema lives here and is built
+ * from the existing TinteBlockSchema without touching tinte.ts.
+ */
+export const TinteThemeSchema = z.object({
+  light: TinteBlockSchema,
+  dark: TinteBlockSchema.optional(),
+  name: z.string().optional(),
+  author: z.string().optional(),
+});
+
+export type TinteThemeInput = z.infer<typeof TinteThemeSchema>;
+
+/**
+ * A single typographic role: the exact size/leading/weight triple an agent is
+ * allowed to use. Sizes are px, lineHeight is a unitless ratio, weight is a
+ * numeric CSS font-weight.
+ */
+export const TypeRoleSchema = z.object({
+  size: z.number().positive().describe("Font size in px"),
+  lineHeight: z.number().positive().describe("Unitless line-height ratio"),
+  weight: z
+    .number()
+    .int()
+    .min(100)
+    .max(900)
+    .describe("Numeric CSS font-weight"),
+});
+
+export type TypeRole = z.infer<typeof TypeRoleSchema>;
+
+export const TYPE_ROLE_NAMES = [
+  "display",
+  "title",
+  "heading",
+  "body",
+  "label",
+  "mono",
+] as const;
+
+export const TypographySchema = z.object({
+  families: z.object({
+    sans: z.string().min(1),
+    mono: z.string().min(1),
+  }),
+  roles: z.object({
+    display: TypeRoleSchema,
+    title: TypeRoleSchema,
+    heading: TypeRoleSchema,
+    body: TypeRoleSchema,
+    label: TypeRoleSchema,
+    mono: TypeRoleSchema,
+  }),
+});
+
+export type Typography = z.infer<typeof TypographySchema>;
+
+/**
+ * How the primary action is expressed.
+ * - "hue": a saturated accent color owns the CTA.
+ * - "inverted": the CTA is a foreground/background inversion, no accent hue.
+ *   (Spike finding: 2/3 of surveyed sites use inversion, not a hue.)
+ */
+export const PrimaryStyleSchema = z.enum(["hue", "inverted"]);
+
+export type PrimaryStyle = z.infer<typeof PrimaryStyleSchema>;
+
+export const TinteIdentitySchema = z.object({
+  name: z.string().min(1),
+  theme: TinteThemeSchema,
+  typography: TypographySchema,
+  radius: z.string().min(1).describe('CSS length, e.g. "2px" or "0.5rem"'),
+  primaryStyle: PrimaryStyleSchema,
+  voiceWords: z.array(z.string()).optional(),
+  dosDonts: z.array(z.string()).optional(),
+  tokensCssUrl: z.string().optional(),
+});
+
+export type TinteIdentity = z.infer<typeof TinteIdentitySchema>;

--- a/skills/tinte/SKILL.md
+++ b/skills/tinte/SKILL.md
@@ -173,3 +173,34 @@ Tinte uses 13 semantic OKLCH tokens per mode (light/dark):
 | `ac_3` | Accent 3 |
 
 These compile to 30+ shadcn CSS variables (background, foreground, card, primary, secondary, muted, accent, destructive, chart-1..5, sidebar-*, etc.) with OKLCH color space formatting.
+
+## Design system compiler (Agent Plugins)
+
+tinte compiles a project identity into an installable Agent Plugin (agent-plugins.org 1.0.0)
+so coding agents generate on-brand UI instead of default slop.
+
+```bash
+tinte build --plugin --config tinte.config.json --out ./acme-plugin
+# emits: plugin.json + skills/<name>-design/SKILL.md (composition law + identity)
+#        + references/tokens.css (OKLCH token API from the theme graph)
+
+tinte lint src/            # scan for hex/rgb/hsl literals and Tailwind palette classes
+tinte lint --json          # machine-readable; exit 1 on violations (CI gate)
+```
+
+### Extracting an identity from a reference site
+
+The CLI never guesses colors. The agent looks, the CLI does the math:
+
+```bash
+tinte from --emit-script > extract.js
+agent-browser open https://example.com && agent-browser wait --load networkidle
+agent-browser eval "$(cat extract.js)" > candidates.json
+# The agent (vision) reviews a screenshot to assign semantic roles if needed.
+tinte from --normalize candidates.json --name example --out draft-identity.json
+# Draft only: fill voiceWords/dosDonts by hand, then validate strictly via tinte build.
+```
+
+`--normalize` detects `primaryStyle: "inverted"` (sites whose CTA is a foreground/background
+pair, not a hue) and normalizes pill radii. Tokens that need app states (destructive, ring,
+input) are reported as warnings, never invented.


### PR DESCRIPTION
## What

tinte's pivot slice 1-4: compile a project's design identity into an installable Agent Plugin (agent-plugins.org 1.0.0) so coding agents (v0, Claude Code, Cursor, Codex) generate on-brand UI instead of default slop.

Three new CLI commands plus the identity schema:

- `tinte build --plugin`: reads `tinte.config.json` (new `TinteIdentitySchema` in @tinte/core: theme graph + typography roles + radius + `primaryStyle: hue|inverted`), emits `plugin.json` + `skills/<name>-design/SKILL.md` (landing composition template with identity slots filled) + `references/tokens.css` (OKLCH token API from the theme graph). Without `--plugin` it emits design.md + tokens.css standalone.
- `tinte lint [paths]`: scans for hex/rgb/hsl literals and Tailwind palette classes that bypass the token system. `--json`, exit 1 on violations (CI gate), `tinte-ignore` escapes, tokens.css exempt.
- `tinte from`: deterministic half of extraction. `--emit-script` prints the agent-browser computed-styles walker; `--normalize` reduces candidates (area+count weighting, decorative outlier drop, pill radii normalization), converts to OKLCH, detects inverted-primary sites, and emits a draft identity. The agent looks, the CLI does the math; drafts are validated strictly by `build`.

## Evidence behind the design

- A/B experiment (20 landings, 4 cells, blind judged): the composition template moved layout/typography/density/copy, not just palette. Claude Code cell: +1.65 headline score, tells 6.8 to 3.2. Treatment outputs had zero color literals in 9/10 runs; the one violation (14 hex) is caught by `tinte lint` in its test fixture.
- Extraction spike on linear.app/stripe.com/vercel.com: computed styles bypass CSS CORS entirely; 2 of 3 real sites have no primary hue (CTA = fg/bg inversion), hence `primaryStyle: "inverted"` in the schema.

## Verified

- 20/20 bun tests across build/lint/from (fixtures include the real vercel.com extraction data and the A/B violation case).
- E2E smoke: built the Cronwatch plugin (valid plugin.json, SKILL.md with no unfilled slots, OKLCH tokens.css), linted it clean (exit 0), linted the violating A/B output (15 violations, exit 1).
- Biome clean on all new files. Remaining tsc error at tinte-cli.ts:78 is pre-existing on main.

## Scope notes

- packages/cli tsconfig bumped to ES2022/ESNext + bun-types (commands use import.meta; tsup build unaffected).
- apps/web untouched; the legacy route-group demotion and tinte.dev/design.md route ship in a separate PR.
- skills/tinte/SKILL.md documents the new agent flow.