### PR TITLE
docs: fix CLI package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ curl -X POST https://ray.tinte.dev/api/v1/screenshot \
 
 - `@tinte/core` — Theme primitives, OKLCH color model, type definitions
 - `@tinte/providers` — 19+ format converters (shadcn, VS Code, terminals, design tools)
-- `@tinte/cli` — Agent Plugin compiler (`from`, `build`, `lint`) and theme installer
+- [`tinte`](https://www.npmjs.com/package/tinte) - Agent Plugin compiler (`from`, `build`, `lint`) and theme installer
 
 ## Development
 


### PR DESCRIPTION
The CLI publishes to npm as `tinte` (packages/cli/package.json), not `@tinte/cli`. The README linked a nonexistent package.