### PR TITLE
feat(cli): npm readme, release workflow, and fixes that unbreak the published package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/cli/package.json"
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Detect version change
+        id: version
+        run: |
+          LOCAL=$(jq -r .version package.json)
+          PUBLISHED=$(npm view tinte version 2>/dev/null || echo "0.0.0")
+          echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
+          echo "published=$PUBLISHED" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL" != "$PUBLISHED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $PUBLISHED -> $LOCAL"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($LOCAL), skipping publish"
+          fi
+
+      - name: Install dependencies
+        if: steps.version.outputs.changed == 'true'
+        run: bun install --frozen-lockfile
+        working-directory: .
+
+      - name: Test
+        if: steps.version.outputs.changed == 'true'
+        run: bun test
+
+      - name: Build
+        if: steps.version.outputs.changed == 'true'
+        run: bun run build
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish --access public
+
+      - name: Tag and GitHub Release
+        if: steps.version.outputs.changed == 'true'
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.local }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" --title "v$VERSION" --generate-notes

--- a/bun.lock
+++ b/bun.lock
@@ -187,15 +187,15 @@
     },
     "packages/cli": {
       "name": "tinte",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "bin": {
         "tinte": "dist/cli.js",
       },
       "dependencies": {
-        "@tinte/core": "workspace:*",
         "culori": "^4.0.2",
       },
       "devDependencies": {
+        "@tinte/core": "workspace:*",
         "@types/culori": "^4.0.0",
         "@types/node": "^20.0.0",
         "bun-types": "^1.3.14",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,227 +1,121 @@
-# 🎨 Tinte CLI
+<h3 align="center">
+  <a href="https://tinte.dev" target="_blank">
+    <img src="https://github.com/Railly/tinte/blob/main/apps/web/src/app/icon.svg" width="80" alt="Tinte Logo"/>
+  </a>
+  <br/>
+  <span style="font-weight:600;font-size:20px;color:#2563EB;">tinte</span>
+  <br/>
+  <br/>
+  <a href="https://vercel.com/oss" target="_blank">
+    <img src="https://vercel.com/oss/program-badge.svg" alt="Vercel OSS Program"/>
+  </a>
+</h3>
 
-> Beautiful editor themes with the best DX - install themes instantly to VS Code and Cursor
+<p align="center">
+  Compile your design system into an Agent Plugin. Also the classic Tinte theme installer for VS Code, Cursor, and Zed.
+</p>
 
-## ✨ Features
-
-- **Multi-Editor Support** - Install to VS Code and Cursor with simple flags
-- **Instant Installation** - Download and install editor themes in one command
-- **Multiple Sources** - Install from theme IDs, URLs, or local JSON files
-- **Auto Editor Management** - Automatically closes editor after installation for instant apply
-- **Light/Dark Variants** - Choose your preferred theme variant
-- **Clean Temporary Files** - Smart cleanup of downloaded theme files
-- **Cross-Platform** - Works on macOS, Windows, and Linux
-
-## 🚀 Quick Start
-
-```bash
-# Install globally
-npm install -g @tinte/cli
-
-# Or use with npx/bunx (no installation needed)
-bunx @tinte/cli flexoki-theme
-```
-
-## 📖 Usage
-
-### Install Theme by ID
-```bash
-# Install to VS Code (default)
-tinte flexoki-theme
-tinte catppuccin-mocha
-tinte nord-theme
-
-# Install to Cursor
-tinte flexoki-theme --cursor
-tinte catppuccin-mocha --cursor
-```
-
-### Install from URL
-```bash
-# Direct theme URL to VS Code
-tinte https://tinte.dev/api/themes/abc123
-
-# Theme share URL to Cursor
-tinte https://tinte.dev/r/my-awesome-theme --cursor
-```
-
-### Install from Local File
-```bash
-# Local JSON theme file to VS Code
-tinte ./my-custom-theme.json
-
-# Local theme to Cursor
-tinte ../themes/work-theme.json --cursor
-```
-
-### Options
+## Install
 
 ```bash
-# Install light variant
-tinte flexoki-theme --light
-
-# Install dark variant (default)
-tinte flexoki-theme --dark
-
-# Install to Cursor
-tinte flexoki-theme --cursor
-
-# Don't auto-close editor
-tinte flexoki-theme --no-close
-
-# Custom auto-close timeout
-tinte flexoki-theme --timeout=5000
-
-# Combine options
-tinte flexoki-theme --cursor --light --no-close
+bunx tinte <command>
 ```
 
-### List Installed Themes
+No install step required. For a global binary:
+
 ```bash
-# List themes in VS Code
-tinte list
-
-# List themes in Cursor
-tinte list --cursor
+bun add -g tinte
 ```
 
-### Cleanup Temporary Files
+## Quickstart
+
+### Compile an identity into an Agent Plugin
+
+Reads `./tinte.config.json` (a Tinte identity) and emits a plugin directory a coding agent can load.
+
 ```bash
-tinte cleanup
+bunx tinte build --plugin
 ```
 
-## 🔧 Advanced Usage
+Writes `plugin.json`, `skills/<name>-design/SKILL.md`, and `skills/<name>-design/references/tokens.css`.
 
-### Programmatic API
+Without `--plugin` it emits the two loose artifacts instead:
 
-```typescript
-import { TinteCLI } from '@tinte/cli';
-
-const cli = new TinteCLI();
-
-// Install theme from theme data
-await cli.installTheme(
-  {
-    light: { bg: '#ffffff', tx: '#000000', /* ... */ },
-    dark: { bg: '#000000', tx: '#ffffff', /* ... */ }
-  },
-  'My Custom Theme',
-  { variant: 'dark', autoClose: true }
-);
-
-// Install from URL
-await cli.installFromUrl('https://tinte.dev/api/themes/abc123');
-
-// Install from file
-await cli.installFromFile('./theme.json', 'My Theme');
-
-// Quick install (auto-detect source)
-await cli.quick('flexoki-theme');
-```
-
-### Theme File Format
-
-```json
-{
-  "name": "My Custom Theme",
-  "displayName": "My Custom Theme",
-  "rawTheme": {
-    "light": {
-      "bg": "#ffffff",
-      "tx": "#000000",
-      "pr": "#0066cc",
-      "sc": "#6366f1",
-      "ac_1": "#06b6d4",
-      "ac_2": "#84cc16",
-      "ac_3": "#f59e0b",
-      "ui": "#e5e7eb",
-      "ui_2": "#d1d5db",
-      "ui_3": "#9ca3af",
-      "bg_2": "#f9fafb",
-      "tx_2": "#6b7280",
-      "tx_3": "#9ca3af"
-    },
-    "dark": {
-      "bg": "#000000",
-      "tx": "#ffffff",
-      "pr": "#3b82f6",
-      "sc": "#8b5cf6",
-      "ac_1": "#06b6d4",
-      "ac_2": "#84cc16",
-      "ac_3": "#f59e0b",
-      "ui": "#374151",
-      "ui_2": "#4b5563",
-      "ui_3": "#6b7280",
-      "bg_2": "#111827",
-      "tx_2": "#9ca3af",
-      "tx_3": "#6b7280"
-    }
-  }
-}
-```
-
-## 🎯 Best DX Workflow
-
-1. **Create/Edit Theme** - Use [Tinte Workbench](https://tinte.dev/workbench) to design your theme
-2. **Export Theme** - Get your theme ID or download JSON
-3. **Install Instantly** - `bunx @tinte/cli your-theme-id`
-4. **VS Code Auto-Closes** - Theme is ready when you reopen!
-5. **Iterate Fast** - Repeat the process for quick theme iterations
-
-## 🛠️ Requirements
-
-- **Node.js** 16+
-- **VS Code** installed with `code` command available in PATH
-- **Internet connection** for fetching themes from Tinte
-
-## 🤝 Integration with Tinte Ecosystem
-
-This CLI integrates seamlessly with:
-
-- **[Tinte Workbench](https://tinte.dev/workbench)** - Visual theme editor
-- **[Tinte API](https://tinte.dev/api)** - Theme data and conversion
-- **[Tinte Themes](https://tinte.dev/themes)** - Community theme gallery
-- **VS Code Extension Generation** - Automatic VSIX creation with your branding
-
-## 📋 Examples
-
-### Development Workflow
 ```bash
-# Edit theme in Tinte Workbench → Get theme ID → Install
-bunx @tinte/cli abc123-your-theme-id
-
-# Test local theme file
-bunx @tinte/cli ./dist/my-theme.json --light --no-close
-
-# Quick theme switching
-bunx @tinte/cli flexoki-theme
-bunx @tinte/cli catppuccin-mocha
-bunx @tinte/cli nord-theme
+bunx tinte build
 ```
 
-### Team Sharing
+Writes `design.md` and `tokens.css`.
+
+Flags: `--config <path>` (default `./tinte.config.json`), `--out <dir>` (default `./<name>-plugin`).
+
+### Lint what bypasses the token system
+
+Scans source files for hardcoded colors that should be tokens. Exits `1` when violations are found, so it works as a CI gate.
+
 ```bash
-# Share theme URL with team
-bunx @tinte/cli https://tinte.dev/r/team-brand-theme
-
-# Install from company theme repository
-bunx @tinte/cli https://themes.company.com/api/themes/brand-dark
+bunx tinte lint
+bunx tinte lint src/ app/
+bunx tinte lint --json
 ```
 
-## 🚀 Coming Soon
+### Extract an identity from a reference
 
-- **Theme Sync** - Sync themes across devices
-- **Auto-Update** - Keep themes updated automatically
-- **Theme Sets** - Install multiple related themes
-- **Preview Mode** - Preview themes before installing
-- **Git Integration** - Version control for themes
+Two steps. First print the browser extraction script, run it against a live page with [agent-browser](https://github.com/vercel-labs/agent-browser) or any DOM evaluator, and save the result:
 
-## 📝 License
+```bash
+bunx tinte from --emit-script > extract.js
+```
 
-MIT © [Tinte](https://tinte.dev)
+Then normalize the captured candidates into a draft identity:
 
----
+```bash
+bunx tinte from --normalize candidates.json --name acme --out tinte.config.json
+```
 
-**Made with ❤️ by the Tinte team**
+Without `--out` the identity is printed to stdout.
 
-[Website](https://tinte.dev) • [GitHub](https://github.com/Railly/tinte) • [Twitter](https://twitter.com/raillyhugo)
+### Install a theme into your editor
+
+The classic installer. Accepts a theme slug, a URL, or a local JSON file.
+
+```bash
+bunx tinte flexoki-theme                # VS Code (default)
+bunx tinte flexoki-theme --cursor       # Cursor
+bunx tinte flexoki-theme --zed          # Zed
+bunx tinte flexoki-theme --light        # light variant (default: dark)
+bunx tinte https://tinte.dev/api/themes/slug/flexoki-theme
+bunx tinte ./my-theme.json --zed
+```
+
+Other flags: `--close` auto-closes the editor after install, `--timeout=<ms>` sets the delay (default `3000`).
+
+Housekeeping:
+
+```bash
+bunx tinte list       # list installed Tinte themes
+bunx tinte cleanup    # remove temporary theme files
+```
+
+## For agents
+
+There is an official Tinte skill. Install it into your project:
+
+```bash
+npx skills add Railly/tinte
+```
+
+This installs the `tinte` skill (and `ray`, the preview companion) into `.agents/skills/`, readable by Claude Code, Codex, Cursor, and other agent runtimes.
+
+The same skill is served over HTTP at [tinte.dev/api/skill](https://tinte.dev/api/skill).
+
+For an example of what `tinte build` produces, see [tinte.dev/design.md](https://tinte.dev/design.md) - the design system of tinte.dev itself, compiled by this CLI.
+
+## Links
+
+- Repository: [github.com/Railly/tinte](https://github.com/Railly/tinte)
+- Site: [tinte.dev](https://tinte.dev)
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinte",
-  "version": "1.2.0",
-  "description": "Beautiful editor themes with the best DX - install themes instantly to VS Code, Cursor, and Zed",
+  "version": "1.3.0",
+  "description": "Compile your design system into an Agent Plugin. Also the classic Tinte theme installer for VS Code, Cursor, and Zed.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -38,6 +38,7 @@
     "url": "https://github.com/Railly/tinte/issues"
   },
   "devDependencies": {
+    "@tinte/core": "workspace:*",
     "@types/culori": "^4.0.0",
     "@types/node": "^20.0.0",
     "bun-types": "^1.3.14",
@@ -50,13 +51,13 @@
   },
   "files": [
     "dist/**/*",
+    "assets/**/*",
     "README.md"
   ],
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@tinte/core": "workspace:*",
     "culori": "^4.0.2"
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import {
   type TinteBlock,
   type TinteIdentity,
@@ -9,6 +8,7 @@ import {
   type Typography,
 } from "@tinte/core";
 import { formatCss, oklch, parse } from "culori";
+import { moduleDir } from "../lib/module-dir";
 
 const PLUGIN_SCHEMA_URL =
   "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
@@ -149,7 +149,7 @@ function parseArgs(args: string[]): BuildOptions {
  * bundle sits one level deeper than the package root.
  */
 async function loadTemplate(): Promise<string> {
-  const here = dirname(fileURLToPath(import.meta.url));
+  const here = moduleDir(import.meta.url);
   const candidates = [
     // src/commands/build.ts -> packages/cli/assets
     resolve(here, "../../assets/templates/landing.md"),

--- a/packages/cli/src/commands/from.ts
+++ b/packages/cli/src/commands/from.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { oklch } from "culori";
 import { z } from "zod";
+import { moduleDir } from "../lib/module-dir";
 
 // Intentionally a LOOSE draft schema, not the strict TinteIdentitySchema from
 // @tinte/core: extraction from a homepage cannot derive every token (destructive,
@@ -77,17 +77,7 @@ const OKLCH_CHROMA_SATURATED_THRESHOLD = 0.09;
 const TOP_N_PER_CHANNEL = 10;
 
 function resolveExtractScriptPath(): string {
-  // Works under `tsx` dev (ESM, import.meta.url available) and under the
-  // tsup CJS build (import.meta.url is polyfilled to a file:// URL by
-  // esbuild's cjs interop for `target: node16`, __dirname is also valid
-  // there). Try import.meta first, fall back to __dirname for safety.
-  let dir: string;
-  try {
-    dir = dirname(fileURLToPath(import.meta.url));
-  } catch {
-    // biome-ignore lint/suspicious/noExplicitAny: __dirname is CJS-only
-    dir = (globalThis as any).__dirname ?? process.cwd();
-  }
+  const dir = moduleDir(import.meta.url);
 
   const candidates = [
     // dev via tsx: dir = packages/cli/src/commands

--- a/packages/cli/src/lib/module-dir.ts
+++ b/packages/cli/src/lib/module-dir.ts
@@ -1,0 +1,26 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+declare const __dirname: string | undefined;
+
+/**
+ * Directory of the currently executing module.
+ *
+ * Under `tsx`/`bun` (ESM) this comes from `import.meta.url`. Under the tsup CJS
+ * bundle esbuild replaces `import.meta` with an empty object, so `import.meta.url`
+ * is `undefined` and `fileURLToPath` throws. `__dirname` is the real value there,
+ * so it is checked first and the ESM path is the fallback.
+ */
+export function moduleDir(metaUrl: string | undefined): string {
+  // `__dirname` is a module-scoped binding in CJS, not a property of
+  // globalThis, so it has to be referenced directly and guarded with typeof.
+  if (typeof __dirname === "string" && __dirname.length > 0) {
+    return __dirname;
+  }
+
+  if (typeof metaUrl === "string" && metaUrl.length > 0) {
+    return dirname(fileURLToPath(metaUrl));
+  }
+
+  return process.cwd();
+}

--- a/packages/cli/src/lib/providers/zed.ts
+++ b/packages/cli/src/lib/providers/zed.ts
@@ -1,6 +1,10 @@
+import type {
+  TinteBlock,
+  ZedTheme,
+  ZedThemeFamily,
+  ZedThemeStyle,
+} from "@tinte/core";
 import { formatHex, interpolate, oklch, rgb } from "culori";
-import type { TinteBlock } from "@tinte/core";
-import type { ZedTheme, ZedThemeFamily, ZedThemeStyle } from "@tinte/core";
 
 // Helper functions for color manipulation
 function ensureAlpha(color: string, alpha: number = 1): string {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,6 +1,8 @@
+import type { TinteBlock } from "@tinte/core";
+
 export interface TinteTheme {
-  light: Record<string, string>;
-  dark: Record<string, string>;
+  light: TinteBlock;
+  dark: TinteBlock;
 }
 
 export interface EditorInstallOptions {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,6 +11,10 @@ export default defineConfig([
     sourcemap: true,
     minify: false,
     target: "node16",
+    // Workspace packages ship TypeScript sources, so they must be inlined into
+    // the published bundle. Without this they stay external and the binary
+    // crashes at require time on a consumer machine.
+    noExternal: [/^@tinte\//],
     banner: {
       js: "#!/usr/bin/env node",
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     ".": {
       "bun": "./src/index.ts",
       "types": "./src/index.ts",
+      "node": "./src/index.ts",
       "import": "./src/index.ts"
     }
   },


### PR DESCRIPTION
The npm page for `tinte` showed the old theme-installer README and none of the design system compiler commands. Fixing that surfaced three bugs that make the published package unusable for those commands.

## README

Rewrote `packages/cli/README.md`: OSS Program badge, one-line pitch, install, and a quickstart for the real verified surface (`build --plugin`, `lint`, `from --emit-script/--normalize`, plus the classic installer). Adds a "For agents" section pointing at `npx skills add Railly/tinte` and `tinte.dev/api/skill`.

## Bugs found while verifying the build

These affect what consumers get from npm, not just docs.

1. **`assets/` was never published.** `files` listed only `dist` and `README.md`, but `build` and `from` resolve `../assets/...` at runtime. Both commands failed on any installed copy.
2. **`@tinte/core` stayed external in the CJS bundle.** tsup externalizes dependencies by default, and core is a workspace package that ships TypeScript with no `node` export condition, so the binary threw `ERR_PACKAGE_PATH_NOT_EXPORTED` on startup. Fixed with `noExternal` so it is inlined. 1.2.0 predates the `build`/`from` commands and does not have this bug, so it is a regression from the packages/cli refactor.
3. **`"@tinte/core": "workspace:*"` was a runtime dependency.** That protocol is published literally, so `npm install tinte` failed with `EUNSUPPORTEDPROTOCOL`. Now bundled, so it moved to devDependencies.

Also fixed: `import.meta` is replaced with `{}` by esbuild in the CJS build, so `import.meta.url` was undefined and asset resolution fell through to `process.cwd()`. Extracted `moduleDir()`, which prefers the CJS `__dirname` binding and falls back to the ESM path. And `TinteTheme` typed its blocks as `Record<string, string>` while `tinteToZed` requires `TinteBlock`, which broke the dts build and therefore `prepublishOnly`.

## Release

No release automation existed. Added `.github/workflows/release.yml`, adapted from the trx workflow: triggers on `packages/cli/package.json` changes on main, compares local version against the registry, and publishes via npm trusted publishing (OIDC, `id-token: write`) so no token secret is needed. Version bumped to 1.3.0.

Trusted publishing requires the publisher to be configured once on npmjs.com for this repo and workflow file. Until then the workflow will fail at the publish step.

## Verification

Packed the tarball and installed it into a clean project outside the repo:

```
files: ['dist/**/*', 'assets/**/*', 'README.md']
deps:  {'culori': '^4.0.2'}

$ ./node_modules/.bin/tinte build --plugin
plugin.json
skills/tinte-design/SKILL.md
skills/tinte-design/references/tokens.css

$ ./node_modules/.bin/tinte from --emit-script
// tinte from --emit-script

$ ./node_modules/.bin/tinte lint
tinte lint: clean - no hardcoded colors found
```

`bun test packages/cli`: 20 pass, 0 fail. Biome clean on changed files.
