### PR TITLE
refactor(providers): decouple from React, add tinte export

### DIFF
--- a/apps/web/src/components/preview/unified-preview.tsx
+++ b/apps/web/src/components/preview/unified-preview.tsx
@@ -2,9 +2,9 @@ import type { TinteTheme } from "@tinte/core";
 import {
   convertTheme,
   convertTinteToVSCode,
-  getPreviewableProvider,
   tinteToZed,
 } from "@tinte/providers";
+import { getPreviewableProviderReact } from "@tinte/providers/react";
 import { useQueryState } from "nuqs";
 import { memo, useMemo } from "react";
 import {
@@ -25,7 +25,7 @@ export const UnifiedPreview = memo(function UnifiedPreview({
   const [provider] = useQueryState("provider", { defaultValue: "shadcn" });
   const vscodeOverrides = useVSCodeOverrides();
   const zedOverrides = useZedOverrides();
-  const currentProvider = getPreviewableProvider(provider || "shadcn");
+  const currentProvider = getPreviewableProviderReact(provider || "shadcn");
 
   // Use special conversion with overrides for VS Code and Zed
   const converted = useMemo(() => {

--- a/apps/web/src/components/shared/providers/provider-experiment-tabs.tsx
+++ b/apps/web/src/components/shared/providers/provider-experiment-tabs.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import type { TinteTheme } from "@tinte/core";
+import { exportTheme, getAvailableProviders } from "@tinte/providers";
+import { previewableProviders } from "@tinte/providers/react";
 import { Copy, Download, ExternalLink } from "lucide-react";
 import * as React from "react";
 import { Badge } from "@/components/ui/badge";
@@ -13,13 +16,7 @@ import {
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { makePolineFromTinte, polineRampHex } from "@/lib/theme";
-import {
-  exportTheme,
-  getAvailableProviders,
-  getPreviewableProviders,
-} from "@tinte/providers";
 import { cn } from "@/lib/utils";
-import type { TinteTheme } from "@tinte/core";
 
 interface ProviderExperimentTabsProps {
   theme: TinteTheme | null;
@@ -163,7 +160,6 @@ export function ProviderExperimentTabs({
   className,
 }: ProviderExperimentTabsProps) {
   const availableProviders = getAvailableProviders();
-  const previewableProviders = getPreviewableProviders();
 
   // Group providers by category
   const providersByCategory = React.useMemo(() => {

--- a/apps/web/src/components/shared/providers/provider-switcher.tsx
+++ b/apps/web/src/components/shared/providers/provider-switcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getAvailableProviders } from "@tinte/providers";
+import { previewableProviders as reactPreviewableProviders } from "@tinte/providers/react";
 import { ChevronsUpDown, Clock, FlaskConical } from "lucide-react";
 import { useQueryState } from "nuqs";
 import * as React from "react";
@@ -32,14 +33,21 @@ export function ProviderSwitcher({ className }: ProviderSwitcherProps) {
   const [open, setOpen] = React.useState(false);
 
   const availableProviders = React.useMemo(() => {
-    return getAvailableProviders().map((p) => ({
-      id: p.metadata.id,
-      name: p.metadata.name,
-      icon: p.metadata.icon,
-      category: p.metadata.category,
-      available: true,
-      experimental: p.metadata.experimental,
-    }));
+    const order = getAvailableProviders().map((p) => p.metadata.id);
+    const byId = new Map(
+      reactPreviewableProviders.map((p) => [p.metadata.id, p]),
+    );
+    return order
+      .map((id) => byId.get(id))
+      .filter((p): p is (typeof reactPreviewableProviders)[number] => !!p)
+      .map((p) => ({
+        id: p.metadata.id,
+        name: p.metadata.name,
+        icon: p.icon,
+        category: p.metadata.category,
+        available: true,
+        experimental: p.metadata.experimental,
+      }));
   }, []);
 
   const plannedProviders = React.useMemo(() => {

--- a/apps/web/src/lib/theme/utils.ts
+++ b/apps/web/src/lib/theme/utils.ts
@@ -1,23 +1,25 @@
 "use client";
 
-import type { ShadcnTheme } from "@/types/shadcn";
 import type { TinteTheme } from "@tinte/core";
-import { DEFAULT_THEME } from "@/utils/default-theme";
-import {
-  downloadFile,
-  downloadJSON,
-  downloadMultipleFiles,
-} from "@/lib/file-download";
 import {
   convertAllThemes,
   convertTheme,
   exportAllThemes,
   exportTheme,
   getAvailableProviders,
-  getPreviewableProvider,
-  getPreviewableProviders,
   getProvider,
 } from "@tinte/providers";
+import {
+  getPreviewableProviderReact,
+  previewableProviders,
+} from "@tinte/providers/react";
+import {
+  downloadFile,
+  downloadJSON,
+  downloadMultipleFiles,
+} from "@/lib/file-download";
+import type { ShadcnTheme } from "@/types/shadcn";
+import { DEFAULT_THEME } from "@/utils/default-theme";
 import type { ThemeData } from "./tokens";
 
 export type ThemeMode = "light" | "dark";
@@ -230,7 +232,6 @@ export function extractThemeColors(
 
 export function useThemeAdapters() {
   const availableProviders = getAvailableProviders();
-  const previewableProviders = getPreviewableProviders();
 
   return {
     availableProviders,
@@ -257,7 +258,7 @@ export function useThemeAdapters() {
     },
 
     getPreviewableProvider: (providerId: string) => {
-      return getPreviewableProvider(providerId);
+      return getPreviewableProviderReact(providerId);
     },
   };
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -75,6 +75,27 @@ bunx tinte from --normalize candidates.json --name acme --out tinte.config.json
 
 Without `--out` the identity is printed to stdout.
 
+### Export a theme file
+
+Turns an identity into a real theme file for one of the 14 providers. Reads the same `tinte.config.json` the compiler uses.
+
+```bash
+bunx tinte export --list                          # see every provider
+bunx tinte export --provider vscode --out themes/ # write themes/vscode-theme.json
+bunx tinte export --provider zed --json           # print to stdout
+```
+
+Providers span editors (VS Code, Zed, Shiki, Codex), terminals (Kitty, Alacritty, Warp, Windows Terminal), UI (shadcn/ui), and design tools (GIMP).
+
+Flags: `--config <path>` (default `./tinte.config.json`), `--out <dir>`, `--out-file <path>` for an exact filename, `--json` to print instead of write.
+
+Exits `1` on an unknown provider or an unreadable config, so it works as a CI step. A repo can regenerate its themes on every build and diff the result:
+
+```bash
+tinte export --provider vscode --out themes/
+git diff --exit-code themes/
+```
+
 ### Install a theme into your editor
 
 The classic installer. Accepts a theme slug, a URL, or a local JSON file.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,5 @@
 import { buildCommand } from "./commands/build";
+import { exportCommand } from "./commands/export";
 import { fromCommand } from "./commands/from";
 import { lintCommand } from "./commands/lint";
 import { TinteCLI } from "./tinte-cli";
@@ -17,6 +18,9 @@ async function main() {
       break;
     case "from":
       process.exit(await fromCommand(args.slice(1)));
+      break;
+    case "export":
+      process.exit(await exportCommand(args.slice(1)));
       break;
   }
 
@@ -38,6 +42,11 @@ Design system compiler (Agent Plugins):
   bunx tinte lint [paths...]         # Scan for colors that bypass the token system
   bunx tinte from --emit-script      # Print the agent-browser extraction script
   bunx tinte from --normalize <json> # Normalize extracted candidates to a draft identity
+
+Theme export (generate theme files from an identity):
+  bunx tinte export --list           # List available providers
+  bunx tinte export --provider vscode --out themes/
+  bunx tinte export --provider zed --json
 
 Options:
   --light                           # Install light variant

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { exportCommand } from "./export";
+
+let dir: string;
+let logs: string[];
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+
+const THEME_BLOCK = {
+  bg: "#ffffff",
+  bg_2: "#fafafa",
+  ui: "#ebebeb",
+  ui_2: "#e0e0e0",
+  ui_3: "#c9c9c9",
+  tx: "#0a0a0a",
+  tx_2: "#666666",
+  tx_3: "#8f8f8f",
+  pr: "#0a0a0a",
+  sc: "#404040",
+  ac_1: "#0483c5",
+  ac_2: "#e26d14",
+  ac_3: "#bb1b3f",
+};
+
+function writeConfig(path: string, contents: unknown) {
+  writeFileSync(path, JSON.stringify(contents), "utf-8");
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "tinte-export-"));
+  logs = [];
+  originalLog = console.log;
+  originalError = console.error;
+  console.log = (...parts: unknown[]) => {
+    logs.push(parts.map(String).join(" "));
+  };
+  console.error = (...parts: unknown[]) => {
+    logs.push(parts.map(String).join(" "));
+  };
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("exportCommand", () => {
+  it("writes a VS Code theme from an identity config", async () => {
+    const config = join(dir, "tinte.config.json");
+    writeConfig(config, {
+      name: "acme",
+      theme: { light: THEME_BLOCK, dark: THEME_BLOCK },
+    });
+
+    const code = await exportCommand([
+      "--provider",
+      "vscode",
+      "--config",
+      config,
+      "--out",
+      dir,
+    ]);
+
+    expect(code).toBe(0);
+
+    const written = join(dir, "vscode-theme.json");
+    expect(existsSync(written)).toBe(true);
+
+    const theme = JSON.parse(readFileSync(written, "utf-8"));
+    expect(theme.colors).toBeDefined();
+    expect(theme.tokenColors.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a bare light/dark config without a theme wrapper", async () => {
+    const config = join(dir, "bare.json");
+    writeConfig(config, { light: THEME_BLOCK, dark: THEME_BLOCK });
+
+    const code = await exportCommand([
+      "--provider",
+      "vscode",
+      "--config",
+      config,
+      "--out",
+      dir,
+    ]);
+
+    expect(code).toBe(0);
+    expect(existsSync(join(dir, "vscode-theme.json"))).toBe(true);
+  });
+
+  it("honors --out-file over --out", async () => {
+    const config = join(dir, "tinte.config.json");
+    writeConfig(config, { theme: { light: THEME_BLOCK, dark: THEME_BLOCK } });
+    const target = join(dir, "nested", "custom-name.json");
+
+    const code = await exportCommand([
+      "--provider",
+      "vscode",
+      "--config",
+      config,
+      "--out-file",
+      target,
+    ]);
+
+    expect(code).toBe(0);
+    expect(existsSync(target)).toBe(true);
+  });
+
+  it("prints to stdout with --json and writes nothing", async () => {
+    const config = join(dir, "tinte.config.json");
+    writeConfig(config, { theme: { light: THEME_BLOCK, dark: THEME_BLOCK } });
+
+    const code = await exportCommand([
+      "--provider",
+      "vscode",
+      "--config",
+      config,
+      "--json",
+    ]);
+
+    expect(code).toBe(0);
+    expect(existsSync(join(dir, "vscode-theme.json"))).toBe(false);
+    expect(JSON.parse(logs.join("\n")).colors).toBeDefined();
+  });
+
+  it("lists every registered provider", async () => {
+    const code = await exportCommand(["--list"]);
+
+    expect(code).toBe(0);
+    const output = logs.join("\n");
+    expect(output).toContain("vscode");
+    expect(output).toContain("zed");
+  });
+
+  it("fails with exit 1 on an unknown provider", async () => {
+    const code = await exportCommand(["--provider", "not-a-provider"]);
+
+    expect(code).toBe(1);
+    expect(logs.join("\n")).toContain("Unknown provider");
+  });
+
+  it("fails with exit 1 when the config is missing", async () => {
+    const code = await exportCommand([
+      "--provider",
+      "vscode",
+      "--config",
+      join(dir, "absent.json"),
+    ]);
+
+    expect(code).toBe(1);
+    expect(logs.join("\n")).toContain("Could not read");
+  });
+
+  it("fails with exit 1 when the config has no theme", async () => {
+    const config = join(dir, "empty.json");
+    writeConfig(config, { name: "acme" });
+
+    const code = await exportCommand([
+      "--provider",
+      "vscode",
+      "--config",
+      config,
+    ]);
+
+    expect(code).toBe(1);
+    expect(logs.join("\n")).toContain("no theme");
+  });
+
+  it("fails with exit 1 when no provider is given", async () => {
+    const code = await exportCommand([]);
+
+    expect(code).toBe(1);
+    expect(logs.join("\n")).toContain("Missing --provider");
+  });
+});

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,207 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type { TinteTheme } from "@tinte/core";
+import {
+  getAvailableProviders,
+  getProvider,
+  hasProvider,
+} from "@tinte/providers";
+
+interface ExportOptions {
+  provider: string;
+  configPath: string;
+  outDir?: string;
+  outFile?: string;
+  json: boolean;
+  list: boolean;
+}
+
+const USAGE = `Usage:
+  tinte export --provider <id> [options]
+  tinte export --list
+
+Options:
+  --provider <id>     Provider to export to (e.g. vscode, zed, kitty)
+  --config <path>     Identity config to read (default: ./tinte.config.json)
+  --out <dir>         Directory to write into (default: current directory)
+  --out-file <path>   Exact file to write, overrides --out
+  --list              List available providers and exit
+  --json              Print the exported content to stdout as JSON
+
+Examples:
+  tinte export --list
+  tinte export --provider vscode --out themes/
+  tinte export --provider zed --config ./brand.json --out-file themes/brand.json
+  tinte export --provider kitty --json`;
+
+function parseArgs(args: string[]): ExportOptions | { error: string } {
+  const options: ExportOptions = {
+    provider: "",
+    configPath: "./tinte.config.json",
+    json: false,
+    list: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === "--list") {
+      options.list = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--provider" || arg.startsWith("--provider=")) {
+      const value = arg.includes("=") ? arg.split("=")[1] : args[++i];
+      if (!value) return { error: "--provider requires a value" };
+      options.provider = value;
+    } else if (arg === "--config" || arg.startsWith("--config=")) {
+      const value = arg.includes("=") ? arg.split("=")[1] : args[++i];
+      if (!value) return { error: "--config requires a value" };
+      options.configPath = value;
+    } else if (arg === "--out" || arg.startsWith("--out=")) {
+      const value = arg.includes("=") ? arg.split("=")[1] : args[++i];
+      if (!value) return { error: "--out requires a value" };
+      options.outDir = value;
+    } else if (arg === "--out-file" || arg.startsWith("--out-file=")) {
+      const value = arg.includes("=") ? arg.split("=")[1] : args[++i];
+      if (!value) return { error: "--out-file requires a value" };
+      options.outFile = value;
+    } else if (arg === "--help" || arg === "-h") {
+      return { error: "" };
+    } else {
+      return { error: `Unknown argument: ${arg}` };
+    }
+  }
+
+  return options;
+}
+
+/**
+ * Reads a Tinte identity config and returns the theme block the providers
+ * consume. Accepts both a full identity (`{ name, theme: { light, dark } }`)
+ * and a bare `{ light, dark }` theme, since both shapes exist in the wild.
+ */
+function readTheme(configPath: string): TinteTheme {
+  const resolved = resolve(configPath);
+  const raw = readFileSync(resolved, "utf-8");
+  const parsed = JSON.parse(raw);
+
+  const theme = parsed.theme ?? parsed;
+
+  if (!theme?.light || !theme?.dark) {
+    throw new Error(
+      `${configPath} has no theme: expected "theme.light" and "theme.dark" (or a bare "light"/"dark" object)`,
+    );
+  }
+
+  return {
+    light: theme.light,
+    dark: theme.dark,
+    name: parsed.name ?? theme.name,
+    author: parsed.author ?? theme.author,
+  };
+}
+
+function listProviders(): number {
+  const providers = getAvailableProviders();
+  const byCategory = new Map<string, typeof providers>();
+
+  for (const provider of providers) {
+    const category = provider.metadata.category;
+    const group = byCategory.get(category) ?? [];
+    group.push(provider);
+    byCategory.set(category, group);
+  }
+
+  console.log(`${providers.length} providers available:\n`);
+
+  for (const [category, group] of [...byCategory].sort()) {
+    console.log(`  ${category}`);
+    for (const provider of group.sort((a, b) =>
+      a.metadata.id.localeCompare(b.metadata.id),
+    )) {
+      const id = provider.metadata.id.padEnd(18);
+      const experimental = provider.metadata.experimental
+        ? " (experimental)"
+        : "";
+      console.log(`    ${id}${provider.metadata.name}${experimental}`);
+    }
+    console.log("");
+  }
+
+  return 0;
+}
+
+export async function exportCommand(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+
+  if ("error" in parsed) {
+    if (parsed.error) console.error(`${parsed.error}\n`);
+    console.log(USAGE);
+    return parsed.error ? 1 : 0;
+  }
+
+  if (parsed.list) {
+    return listProviders();
+  }
+
+  if (!parsed.provider) {
+    console.error("Missing --provider\n");
+    console.log(USAGE);
+    return 1;
+  }
+
+  if (!hasProvider(parsed.provider)) {
+    const available = getAvailableProviders()
+      .map((p) => p.metadata.id)
+      .sort()
+      .join(", ");
+    console.error(`Unknown provider: ${parsed.provider}`);
+    console.error(`Available: ${available}`);
+    return 1;
+  }
+
+  let theme: TinteTheme;
+  try {
+    theme = readTheme(parsed.configPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Could not read ${parsed.configPath}: ${message}`);
+    return 1;
+  }
+
+  const provider = getProvider(parsed.provider);
+  if (!provider) {
+    console.error(`Unknown provider: ${parsed.provider}`);
+    return 1;
+  }
+
+  let output: ReturnType<typeof provider.export>;
+  try {
+    output = provider.export(theme);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`${parsed.provider} failed to export: ${message}`);
+    return 1;
+  }
+
+  if (parsed.json) {
+    console.log(output.content);
+    return 0;
+  }
+
+  const destination = parsed.outFile
+    ? resolve(parsed.outFile)
+    : resolve(join(parsed.outDir ?? ".", output.filename));
+
+  try {
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, output.content, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Could not write ${destination}: ${message}`);
+    return 1;
+  }
+
+  console.log(`${parsed.provider} -> ${destination}`);
+  return 0;
+}

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -34,6 +34,11 @@
       "bun": "./src/provider-utils/vscode-download.ts",
       "types": "./src/provider-utils/vscode-download.ts",
       "import": "./src/provider-utils/vscode-download.ts"
+    },
+    "./react": {
+      "bun": "./src/react/index.tsx",
+      "types": "./src/react/index.tsx",
+      "import": "./src/react/index.tsx"
     }
   },
   "dependencies": {

--- a/packages/providers/src/providers/alacritty.ts
+++ b/packages/providers/src/providers/alacritty.ts
@@ -1,4 +1,3 @@
-import { AlacrittyIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import {
   createPolineColorMapping,
@@ -6,7 +5,7 @@ import {
   getThemeName,
   toYAML,
 } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface AlacrittyTheme {
   colors: {
@@ -110,9 +109,7 @@ function generateAlacrittyTheme(
   };
 }
 
-import { AlacrittyPreview } from "@/components/preview/alacritty/alacritty-preview";
-
-export const alacrittyProvider: PreviewableProvider<{
+export const alacrittyProvider: ThemeProvider<{
   light: AlacrittyTheme;
   dark: AlacrittyTheme;
 }> = {
@@ -122,7 +119,6 @@ export const alacrittyProvider: PreviewableProvider<{
     description: "Cross-platform, OpenGL terminal emulator",
     category: "terminal",
     tags: ["terminal", "opengl", "cross-platform"],
-    icon: AlacrittyIcon,
     website: "https://alacritty.org/",
     documentation: "https://alacritty.org/config.html",
   },
@@ -164,9 +160,5 @@ export const alacrittyProvider: PreviewableProvider<{
       );
 
     return validateTheme(output.light) && validateTheme(output.dark);
-  },
-
-  preview: {
-    component: AlacrittyPreview,
   },
 };

--- a/packages/providers/src/providers/banana.ts
+++ b/packages/providers/src/providers/banana.ts
@@ -1,8 +1,6 @@
-import { BananaPreview } from "@/components/preview/banana/banana-preview";
-import { BananaIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import { createPolineColorMapping, getThemeName } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface BananaTheme {
   // Brand colors for design generation
@@ -66,7 +64,7 @@ function generateBananaTheme(
   };
 }
 
-export const bananaProvider: PreviewableProvider<{
+export const bananaProvider: ThemeProvider<{
   light: BananaTheme;
   dark: BananaTheme;
 }> = {
@@ -77,7 +75,6 @@ export const bananaProvider: PreviewableProvider<{
       "AI-powered creative partner for marketing assets and digital design",
     category: "other",
     tags: ["ai", "design", "marketing", "creative", "assets", "branding"],
-    icon: BananaIcon,
     website: "https://tinte.com/banana",
     documentation: "https://tinte.com/docs/banana",
   },
@@ -135,9 +132,5 @@ export const bananaProvider: PreviewableProvider<{
       );
 
     return validateTheme(output.light) && validateTheme(output.dark);
-  },
-
-  preview: {
-    component: BananaPreview,
   },
 };

--- a/packages/providers/src/providers/brand-guidelines.ts
+++ b/packages/providers/src/providers/brand-guidelines.ts
@@ -1,7 +1,5 @@
-import { BadgeCheck } from "lucide-react";
-import { BrandGuidelinesPreview } from "@/components/preview/brand-guidelines/brand-guidelines-preview";
 import type { TinteTheme } from "@tinte/core";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface BrandGuidelinesOutput {
   brand: {
@@ -68,188 +66,186 @@ export interface BrandGuidelinesOutput {
   };
 }
 
-export const brandGuidelinesProvider: PreviewableProvider<BrandGuidelinesOutput> =
-  {
-    metadata: {
-      id: "brand-guidelines",
-      name: "Brand Guidelines",
-      icon: BadgeCheck,
-      description:
-        "Comprehensive brand guidelines with logo, typography, and color specifications",
-      category: "design",
-      tags: ["brand", "guidelines", "design-system", "documentation"],
-      website: "https://example.com/brand-guidelines",
-    },
+export const brandGuidelinesProvider: ThemeProvider<BrandGuidelinesOutput> = {
+  metadata: {
+    id: "brand-guidelines",
+    name: "Brand Guidelines",
+    description:
+      "Comprehensive brand guidelines with logo, typography, and color specifications",
+    category: "design",
+    tags: ["brand", "guidelines", "design-system", "documentation"],
+    website: "https://example.com/brand-guidelines",
+  },
 
-    fileExtension: "html",
-    mimeType: "text/html",
+  fileExtension: "html",
+  mimeType: "text/html",
 
-    convert(theme: TinteTheme, currentTheme?: any): BrandGuidelinesOutput {
-      console.log({ theme, currentTheme });
-      const themeName = currentTheme?.name || "";
-      return {
-        brand: {
-          name: themeName,
-          description:
-            "The primary brand reflects the official logo and symbol that should be used in all communications. It combines the symbol and the logotype in a clear relationship. It should be used clearly and consistently.",
+  convert(theme: TinteTheme, currentTheme?: any): BrandGuidelinesOutput {
+    console.log({ theme, currentTheme });
+    const themeName = currentTheme?.name || "";
+    return {
+      brand: {
+        name: themeName,
+        description:
+          "The primary brand reflects the official logo and symbol that should be used in all communications. It combines the symbol and the logotype in a clear relationship. It should be used clearly and consistently.",
+      },
+      logo: {
+        primary:
+          "The primary logo is the official logo and should be used in most cases unless specified otherwise.",
+        variations: [
+          {
+            name: "Dark Background",
+            description: "Use on dark backgrounds",
+            background: theme.dark.bg,
+            logo: theme.light.tx,
+          },
+          {
+            name: "Light Background",
+            description: "Use on light backgrounds",
+            background: theme.light.bg,
+            logo: theme.dark.tx,
+          },
+          {
+            name: "Primary Color",
+            description: "Use on primary color backgrounds",
+            background: theme.light.pr,
+            logo: theme.light.bg,
+          },
+          {
+            name: "Accent Color",
+            description: "Use on accent color backgrounds",
+            background: theme.light.sc,
+            logo: theme.light.bg,
+          },
+        ],
+      },
+      symbol: {
+        description:
+          "The standalone symbol is reserved for specific applications where the full logo doesn't fit appropriately. It should be used in square or circular applications, or when space is extremely limited.",
+        variations: [
+          {
+            name: "Dark",
+            background: theme.dark.bg,
+            color: theme.light.pr,
+          },
+          {
+            name: "Primary",
+            background: theme.light.pr,
+            color: theme.light.bg,
+          },
+          {
+            name: "Light",
+            background: theme.light.bg_2,
+            color: theme.light.pr,
+          },
+          {
+            name: "Bright",
+            background: theme.light.sc,
+            color: theme.dark.tx,
+          },
+        ],
+      },
+      typography: {
+        primary: {
+          name: "Geist Sans",
+          family: "var(--font-geist-sans), system-ui, sans-serif",
+          weights: ["400", "500", "600", "700"],
+          sample:
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz\n1234567890!@#$%^&*()",
         },
-        logo: {
-          primary:
-            "The primary logo is the official logo and should be used in most cases unless specified otherwise.",
-          variations: [
+      },
+      colors: {
+        primary: {
+          name: "Primary Colour",
+          description: `Our primary colours reflect ${themeName}'s core brand identity. They should be used consistently across digital, print, and product experiences.`,
+          palette: [
             {
-              name: "Dark Background",
-              description: "Use on dark backgrounds",
-              background: theme.dark.bg,
-              logo: theme.light.tx,
+              name: "HEX",
+              hex: theme.light.pr,
+              usage: "Primary brand color",
             },
             {
-              name: "Light Background",
-              description: "Use on light backgrounds",
-              background: theme.light.bg,
-              logo: theme.dark.tx,
+              name: "RGB(185, 255, 4)",
+              hex: theme.light.pr,
+              usage: "Digital applications",
             },
             {
-              name: "Primary Color",
-              description: "Use on primary color backgrounds",
-              background: theme.light.pr,
-              logo: theme.light.bg,
+              name: "HEX",
+              hex: theme.light.sc,
+              usage: "Accent color",
             },
             {
-              name: "Accent Color",
-              description: "Use on accent color backgrounds",
-              background: theme.light.sc,
-              logo: theme.light.bg,
+              name: "PANTONE",
+              hex: theme.light.sc,
+              usage: "Print applications",
+            },
+            {
+              name: "HEX",
+              hex: theme.light.sc,
+              usage: "Bright variation",
+            },
+            {
+              name: "COFFEE",
+              hex: theme.dark.pr,
+              usage: "Dark variation",
             },
           ],
         },
-        symbol: {
+        neutral: {
+          name: "Neutral Colors",
           description:
-            "The standalone symbol is reserved for specific applications where the full logo doesn't fit appropriately. It should be used in square or circular applications, or when space is extremely limited.",
-          variations: [
+            "Supporting neutral colors for backgrounds, text, and UI elements.",
+          palette: [
             {
-              name: "Dark",
-              background: theme.dark.bg,
-              color: theme.light.pr,
+              name: "Background",
+              hex: theme.light.bg,
+              usage: "Main background",
             },
             {
-              name: "Primary",
-              background: theme.light.pr,
-              color: theme.light.bg,
+              name: "Surface",
+              hex: theme.light.bg_2,
+              usage: "Elevated surfaces",
             },
             {
-              name: "Light",
-              background: theme.light.bg_2,
-              color: theme.light.pr,
+              name: "Border",
+              hex: theme.light.ui,
+              usage: "Borders and dividers",
             },
             {
-              name: "Bright",
-              background: theme.light.sc,
-              color: theme.dark.tx,
+              name: "Text",
+              hex: theme.light.tx,
+              usage: "Primary text",
+            },
+            {
+              name: "Muted",
+              hex: theme.light.tx_2,
+              usage: "Secondary text",
+            },
+            {
+              name: "Faint",
+              hex: theme.light.tx_3,
+              usage: "Tertiary text",
             },
           ],
         },
-        typography: {
-          primary: {
-            name: "Geist Sans",
-            family: "var(--font-geist-sans), system-ui, sans-serif",
-            weights: ["400", "500", "600", "700"],
-            sample:
-              "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz\n1234567890!@#$%^&*()",
-          },
-        },
-        colors: {
-          primary: {
-            name: "Primary Colour",
-            description: `Our primary colours reflect ${themeName}'s core brand identity. They should be used consistently across digital, print, and product experiences.`,
-            palette: [
-              {
-                name: "HEX",
-                hex: theme.light.pr,
-                usage: "Primary brand color",
-              },
-              {
-                name: "RGB(185, 255, 4)",
-                hex: theme.light.pr,
-                usage: "Digital applications",
-              },
-              {
-                name: "HEX",
-                hex: theme.light.sc,
-                usage: "Accent color",
-              },
-              {
-                name: "PANTONE",
-                hex: theme.light.sc,
-                usage: "Print applications",
-              },
-              {
-                name: "HEX",
-                hex: theme.light.sc,
-                usage: "Bright variation",
-              },
-              {
-                name: "COFFEE",
-                hex: theme.dark.pr,
-                usage: "Dark variation",
-              },
-            ],
-          },
-          neutral: {
-            name: "Neutral Colors",
-            description:
-              "Supporting neutral colors for backgrounds, text, and UI elements.",
-            palette: [
-              {
-                name: "Background",
-                hex: theme.light.bg,
-                usage: "Main background",
-              },
-              {
-                name: "Surface",
-                hex: theme.light.bg_2,
-                usage: "Elevated surfaces",
-              },
-              {
-                name: "Border",
-                hex: theme.light.ui,
-                usage: "Borders and dividers",
-              },
-              {
-                name: "Text",
-                hex: theme.light.tx,
-                usage: "Primary text",
-              },
-              {
-                name: "Muted",
-                hex: theme.light.tx_2,
-                usage: "Secondary text",
-              },
-              {
-                name: "Faint",
-                hex: theme.light.tx_3,
-                usage: "Tertiary text",
-              },
-            ],
-          },
-        },
-        scaling: {
-          description:
-            "Logo should scale proportionally and remain legible across all media. The minimum size for digital applications is 24px height.",
-          sizes: [
-            { percentage: 100, usage: "Standard size" },
-            { percentage: 75, usage: "Medium applications" },
-            { percentage: 50, usage: "Small applications" },
-            { percentage: 25, usage: "Minimum size" },
-          ],
-        },
-      };
-    },
+      },
+      scaling: {
+        description:
+          "Logo should scale proportionally and remain legible across all media. The minimum size for digital applications is 24px height.",
+        sizes: [
+          { percentage: 100, usage: "Standard size" },
+          { percentage: 75, usage: "Medium applications" },
+          { percentage: 50, usage: "Small applications" },
+          { percentage: 25, usage: "Minimum size" },
+        ],
+      },
+    };
+  },
 
-    export(theme: TinteTheme, filename = "brand-guidelines"): ProviderOutput {
-      const guidelines = this.convert(theme);
+  export(theme: TinteTheme, filename = "brand-guidelines"): ProviderOutput {
+    const guidelines = this.convert(theme);
 
-      const html = `<!DOCTYPE html>
+    const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -373,14 +369,10 @@ export const brandGuidelinesProvider: PreviewableProvider<BrandGuidelinesOutput>
 </body>
 </html>`;
 
-      return {
-        content: html,
-        filename: `${filename}.html`,
-        mimeType: this.mimeType,
-      };
-    },
-
-    preview: {
-      component: BrandGuidelinesPreview,
-    },
-  };
+    return {
+      content: html,
+      filename: `${filename}.html`,
+      mimeType: this.mimeType,
+    };
+  },
+};

--- a/packages/providers/src/providers/codex.ts
+++ b/packages/providers/src/providers/codex.ts
@@ -5,9 +5,7 @@ import type {
   TinteTheme,
 } from "@tinte/core";
 import { wcagLuminance } from "culori";
-import { CodexPreview } from "@/components/preview/codex/codex-preview";
-import { CodexIcon } from "@/components/shared/icons";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 function computeContrast(bg: string, fg: string): number {
   const bgLum = wcagLuminance(bg);
@@ -70,14 +68,13 @@ function generateExportContent(theme: CodexTheme): string {
   );
 }
 
-export const codexProvider: PreviewableProvider<CodexTheme> = {
+export const codexProvider: ThemeProvider<CodexTheme> = {
   metadata: {
     id: "codex",
     name: "Codex",
     description: "Theme for OpenAI Codex desktop app",
     category: "editor",
     tags: ["openai", "ai", "codex", "terminal"],
-    icon: CodexIcon,
     website: "https://openai.com/index/introducing-codex/",
   },
 
@@ -92,8 +89,4 @@ export const codexProvider: PreviewableProvider<CodexTheme> = {
   }),
 
   validate: (output: CodexTheme) => !!(output.light && output.dark),
-
-  preview: {
-    component: CodexPreview,
-  },
 };

--- a/packages/providers/src/providers/design-system.ts
+++ b/packages/providers/src/providers/design-system.ts
@@ -1,7 +1,5 @@
-import { Layers } from "lucide-react";
-import { DesignSystemPreview } from "@/components/preview/design-system/design-system-preview";
 import type { TinteTheme } from "@tinte/core";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface DesignSystemOutput {
   brand: {
@@ -120,11 +118,10 @@ function hexToCmyk(hex: string): string {
   return `${Math.round(c * 100)}%, ${Math.round(m * 100)}%, ${Math.round(y * 100)}%, ${Math.round(k * 100)}%`;
 }
 
-export const designSystemProvider: PreviewableProvider<DesignSystemOutput> = {
+export const designSystemProvider: ThemeProvider<DesignSystemOutput> = {
   metadata: {
     id: "design-system",
     name: "Design System",
-    icon: Layers,
     description:
       "A comprehensive library of custom components for consistent, beautiful interfaces",
     category: "design",
@@ -761,9 +758,5 @@ ${system.typography.body.variants.map((v) => `<Text variant="${v.name.toLowerCas
       filename: `${filename}.html`,
       mimeType: this.mimeType,
     };
-  },
-
-  preview: {
-    component: DesignSystemPreview,
   },
 };

--- a/packages/providers/src/providers/gimp.ts
+++ b/packages/providers/src/providers/gimp.ts
@@ -1,10 +1,11 @@
-import { makePolineFromTinte, polineRampHex } from "./poline-base";
 import type { TinteTheme } from "@tinte/core";
 import {
   createPolineColorMapping,
   getDisplayName,
   getThemeName,
   hexToInt,
+  makePolineFromTinte,
+  polineRampHex,
 } from "./poline-base";
 import type { ProviderOutput, ThemeProvider } from "./types";
 

--- a/packages/providers/src/providers/gimp.ts
+++ b/packages/providers/src/providers/gimp.ts
@@ -1,5 +1,3 @@
-import { GimpPreview } from "@/components/preview/gimp/gimp-preview";
-import { GIMPIcon } from "@/components/shared/icons";
 import { makePolineFromTinte, polineRampHex } from "./poline-base";
 import type { TinteTheme } from "@tinte/core";
 import {
@@ -8,7 +6,7 @@ import {
   getThemeName,
   hexToInt,
 } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface GIMPPalette {
   name: string;
@@ -103,7 +101,7 @@ function generateGIMPPalette(
   };
 }
 
-export const gimpProvider: PreviewableProvider<{
+export const gimpProvider: ThemeProvider<{
   light: GIMPPalette;
   dark: GIMPPalette;
 }> = {
@@ -113,7 +111,6 @@ export const gimpProvider: PreviewableProvider<{
     description: "GNU Image Manipulation Program color palette",
     category: "design",
     tags: ["design", "graphics", "image-editing", "palette"],
-    icon: GIMPIcon,
     website: "https://www.gimp.org/",
     documentation: "https://docs.gimp.org/en/gimp-concepts-palettes.html",
   },
@@ -186,9 +183,5 @@ export const gimpProvider: PreviewableProvider<{
       );
 
     return validatePalette(output.light) && validatePalette(output.dark);
-  },
-
-  preview: {
-    component: GimpPreview,
   },
 };

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -19,19 +19,37 @@ export * from "./windows-terminal";
 export * from "./zed";
 export * from "./zed-provider";
 
+import { alacrittyProvider } from "./alacritty";
+import { bananaProvider } from "./banana";
+import { brandGuidelinesProvider } from "./brand-guidelines";
 import { codexProvider } from "./codex";
 import { designSystemProvider } from "./design-system";
+import { gimpProvider } from "./gimp";
+import { kittyProvider } from "./kitty";
 import { ProviderRegistry } from "./registry";
 import { shadcnProvider } from "./shadcn";
 import { shikiProvider } from "./shiki";
+import { slackProvider } from "./slack";
 import { vscodeProvider } from "./vscode";
+import { warpProvider } from "./warp";
+import { windowsTerminalProvider } from "./windows-terminal";
+import { zedProvider } from "./zed-provider";
 
 const registry = new ProviderRegistry();
-registry.registerPreviewable(codexProvider);
-registry.registerPreviewable(shadcnProvider);
-registry.registerPreviewable(vscodeProvider);
-registry.registerPreviewable(shikiProvider);
-registry.registerPreviewable(designSystemProvider);
+registry.register(alacrittyProvider);
+registry.register(bananaProvider);
+registry.register(brandGuidelinesProvider);
+registry.register(codexProvider);
+registry.register(designSystemProvider);
+registry.register(gimpProvider);
+registry.register(kittyProvider);
+registry.register(shadcnProvider);
+registry.register(shikiProvider);
+registry.register(slackProvider);
+registry.register(vscodeProvider);
+registry.register(warpProvider);
+registry.register(windowsTerminalProvider);
+registry.register(zedProvider);
 
 export function getAvailableProviders() {
   return registry.getAll();

--- a/packages/providers/src/providers/kitty.ts
+++ b/packages/providers/src/providers/kitty.ts
@@ -1,12 +1,10 @@
-import { KittyPreview } from "@/components/preview/kitty/kitty-preview";
-import { KittyIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import {
   createPolineColorMapping,
   getDisplayName,
   getThemeName,
 } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface KittyTheme {
   // Basic colors
@@ -100,7 +98,7 @@ function generateKittyTheme(
   };
 }
 
-export const kittyProvider: PreviewableProvider<{
+export const kittyProvider: ThemeProvider<{
   light: KittyTheme;
   dark: KittyTheme;
 }> = {
@@ -110,7 +108,6 @@ export const kittyProvider: PreviewableProvider<{
     description: "Fast, feature-rich, GPU based terminal emulator",
     category: "terminal",
     tags: ["terminal", "gpu", "fast", "python"],
-    icon: KittyIcon,
     website: "https://sw.kovidgoyal.net/kitty/",
     documentation: "https://sw.kovidgoyal.net/kitty/conf/",
   },
@@ -236,9 +233,5 @@ export const kittyProvider: PreviewableProvider<{
       );
 
     return validateTheme(output.light) && validateTheme(output.dark);
-  },
-
-  preview: {
-    component: KittyPreview,
   },
 };

--- a/packages/providers/src/providers/shadcn.ts
+++ b/packages/providers/src/providers/shadcn.ts
@@ -8,9 +8,7 @@ import {
   type ShadcnTheme,
 } from "@tinte/core";
 import { formatHex, oklch } from "culori";
-import { ShadcnPreview } from "@/components/preview/shadcn/shadcn-preview";
-import { ShadcnIcon } from "@/components/shared/icons";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 type ThemeMode = "light" | "dark";
 
@@ -514,7 +512,7 @@ function generateCSSVariables(theme: ShadcnTheme): string {
   return `:root {\n${lightVars}\n}\n\n.dark {\n${darkVars}\n}\n\n${THEME_INLINE_BLOCK}`;
 }
 
-export const shadcnProvider: PreviewableProvider<ShadcnTheme> = {
+export const shadcnProvider: ThemeProvider<ShadcnTheme> = {
   metadata: {
     id: "shadcn",
     name: "shadcn/ui",
@@ -522,7 +520,6 @@ export const shadcnProvider: PreviewableProvider<ShadcnTheme> = {
       "Beautifully designed components built on Radix UI and Tailwind CSS",
     category: "ui",
     tags: ["react", "tailwind", "components", "ui"],
-    icon: ShadcnIcon,
     website: "https://ui.shadcn.com/",
     documentation: "https://ui.shadcn.com/docs",
   },
@@ -538,8 +535,4 @@ export const shadcnProvider: PreviewableProvider<ShadcnTheme> = {
   }),
 
   validate: (output: ShadcnTheme) => !!(output.light && output.dark),
-
-  preview: {
-    component: ShadcnPreview,
-  },
 };

--- a/packages/providers/src/providers/shiki.ts
+++ b/packages/providers/src/providers/shiki.ts
@@ -1,8 +1,6 @@
-import { ShikiPreview } from "@/components/preview/shiki/shiki-preview";
-import { ShikiIcon } from "@/components/shared/icons";
 import type { ShikiCssTheme, ShikiTheme } from "@tinte/core";
 import type { TinteBlock, TinteTheme } from "@tinte/core";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 function mapTinteBlockToShiki(
   block: TinteBlock,
@@ -100,7 +98,7 @@ ${darkVars}
 }`;
 }
 
-export const shikiProvider: PreviewableProvider<ShikiTheme> = {
+export const shikiProvider: ThemeProvider<ShikiTheme> = {
   metadata: {
     id: "shiki",
     name: "Shiki",
@@ -108,7 +106,6 @@ export const shikiProvider: PreviewableProvider<ShikiTheme> = {
       "Syntax highlighter using CSS variables for maximum customization",
     category: "editor",
     tags: ["syntax", "highlighting", "css", "customizable"],
-    icon: ShikiIcon,
     website: "https://shiki.style/",
     documentation:
       "https://shiki.style/guide/theme-colors-manipulation#css-variables-theme",
@@ -125,8 +122,4 @@ export const shikiProvider: PreviewableProvider<ShikiTheme> = {
   }),
 
   validate: (output: ShikiTheme) => !!(output.light && output.dark),
-
-  preview: {
-    component: ShikiPreview,
-  },
 };

--- a/packages/providers/src/providers/shiki.ts
+++ b/packages/providers/src/providers/shiki.ts
@@ -1,5 +1,9 @@
-import type { ShikiCssTheme, ShikiTheme } from "@tinte/core";
-import type { TinteBlock, TinteTheme } from "@tinte/core";
+import type {
+  ShikiCssTheme,
+  ShikiTheme,
+  TinteBlock,
+  TinteTheme,
+} from "@tinte/core";
 import type { ProviderOutput, ThemeProvider } from "./types";
 
 function mapTinteBlockToShiki(

--- a/packages/providers/src/providers/slack.ts
+++ b/packages/providers/src/providers/slack.ts
@@ -1,8 +1,6 @@
-import { SlackPreview } from "@/components/preview/slack/slack-preview";
-import { SlackIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import { createPolineColorMapping, getThemeName } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface SlackTheme {
   // Sidebar colors
@@ -52,7 +50,7 @@ function generateSlackTheme(
   };
 }
 
-export const slackProvider: PreviewableProvider<{
+export const slackProvider: ThemeProvider<{
   light: SlackTheme;
   dark: SlackTheme;
 }> = {
@@ -62,7 +60,6 @@ export const slackProvider: PreviewableProvider<{
     description: "Team collaboration and messaging platform",
     category: "other",
     tags: ["communication", "messaging", "collaboration", "workspace"],
-    icon: SlackIcon,
     website: "https://slack.com/",
     documentation:
       "https://slack.com/help/articles/205166337-Change-your-Slack-theme",
@@ -120,9 +117,5 @@ export const slackProvider: PreviewableProvider<{
       );
 
     return validateTheme(output.light) && validateTheme(output.dark);
-  },
-
-  preview: {
-    component: SlackPreview,
   },
 };

--- a/packages/providers/src/providers/types.ts
+++ b/packages/providers/src/providers/types.ts
@@ -12,7 +12,6 @@ export interface ProviderMetadata {
   description?: string;
   category: "editor" | "terminal" | "ui" | "design" | "other";
   tags: string[];
-  icon?: React.ComponentType<{ className?: string }>;
   website?: string;
   documentation?: string;
   experimental?: boolean;
@@ -28,8 +27,16 @@ export interface ThemeProvider<TOutput = any> {
   validate?(output: TOutput): boolean;
 }
 
+/**
+ * A provider plus the React surface the web app renders for it.
+ *
+ * Everything visual lives here and nowhere else. `ThemeProvider` and the
+ * modules under `./providers/` must stay importable from Node without React,
+ * so the CLI can bundle them. Import this only from the web app.
+ */
 export interface PreviewableProvider<TOutput = any>
   extends ThemeProvider<TOutput> {
+  icon?: React.ComponentType<{ className?: string }>;
   preview: {
     component: React.ComponentType<{ theme: TOutput; className?: string }>;
     defaultProps?: Record<string, any>;

--- a/packages/providers/src/providers/vscode.ts
+++ b/packages/providers/src/providers/vscode.ts
@@ -1,8 +1,6 @@
-import { VSCodePreview } from "@/components/preview/vscode/vscode-preview";
-import { VSCodeIcon } from "@/components/shared/icons";
 import type { TinteBlock, TinteTheme } from "@tinte/core";
 import { shadcnToTinte } from "../provider-utils";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 import type { CodeTemplate } from "@tinte/core";
 export type { CodeTemplate };
@@ -455,7 +453,7 @@ function generateVSCodeThemeFile(themes: {
 
 export { convertTinteToVSCode };
 
-export const vscodeProvider: PreviewableProvider<{
+export const vscodeProvider: ThemeProvider<{
   light: VSCodeTheme;
   dark: VSCodeTheme;
 }> = {
@@ -465,7 +463,6 @@ export const vscodeProvider: PreviewableProvider<{
     description: "The most popular code editor with extensive theme support",
     category: "editor",
     tags: ["editor", "microsoft", "typescript", "javascript"],
-    icon: VSCodeIcon,
     website: "https://code.visualstudio.com/",
     documentation:
       "https://code.visualstudio.com/api/extension-guides/color-theme",
@@ -491,8 +488,4 @@ export const vscodeProvider: PreviewableProvider<{
       output.light?.tokenColors &&
       output.dark?.tokenColors
     ),
-
-  preview: {
-    component: VSCodePreview,
-  },
 };

--- a/packages/providers/src/providers/vscode.ts
+++ b/packages/providers/src/providers/vscode.ts
@@ -1,8 +1,6 @@
-import type { TinteBlock, TinteTheme } from "@tinte/core";
+import type { CodeTemplate, TinteBlock, TinteTheme } from "@tinte/core";
 import { shadcnToTinte } from "../provider-utils";
 import type { ProviderOutput, ThemeProvider } from "./types";
-
-import type { CodeTemplate } from "@tinte/core";
 export type { CodeTemplate };
 export { codeTemplates } from "./vscode-code-templates";
 

--- a/packages/providers/src/providers/warp.ts
+++ b/packages/providers/src/providers/warp.ts
@@ -1,5 +1,3 @@
-import { WarpPreview } from "@/components/preview/warp/warp-preview";
-import { WarpIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import {
   createPolineColorMapping,
@@ -7,7 +5,7 @@ import {
   getThemeName,
   toYAML,
 } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface WarpTheme {
   accent: string;
@@ -79,7 +77,7 @@ function generateWarpTheme(
   };
 }
 
-export const warpProvider: PreviewableProvider<{
+export const warpProvider: ThemeProvider<{
   light: WarpTheme;
   dark: WarpTheme;
 }> = {
@@ -89,7 +87,6 @@ export const warpProvider: PreviewableProvider<{
     description: "Modern terminal with AI and collaboration features",
     category: "terminal",
     tags: ["terminal", "ai", "modern", "collaboration"],
-    icon: WarpIcon,
     website: "https://www.warp.dev/",
     documentation: "https://docs.warp.dev/appearance/custom-themes",
   },
@@ -150,9 +147,5 @@ ${toYAML(warpTheme)}`;
       );
 
     return validateTheme(output.light) && validateTheme(output.dark);
-  },
-
-  preview: {
-    component: WarpPreview,
   },
 };

--- a/packages/providers/src/providers/windows-terminal.ts
+++ b/packages/providers/src/providers/windows-terminal.ts
@@ -1,5 +1,3 @@
-import { WindowsTerminalPreview } from "@/components/preview/windows-terminal/windows-terminal-preview";
-import { WindowsTerminalIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import {
   createPolineColorMapping,
@@ -7,7 +5,7 @@ import {
   getThemeName,
   toJSON,
 } from "./poline-base";
-import type { PreviewableProvider, ProviderOutput } from "./types";
+import type { ProviderOutput, ThemeProvider } from "./types";
 
 export interface WindowsTerminalTheme {
   name: string;
@@ -85,7 +83,7 @@ function generateWindowsTerminalTheme(
   };
 }
 
-export const windowsTerminalProvider: PreviewableProvider<{
+export const windowsTerminalProvider: ThemeProvider<{
   light: WindowsTerminalTheme;
   dark: WindowsTerminalTheme;
 }> = {
@@ -95,7 +93,6 @@ export const windowsTerminalProvider: PreviewableProvider<{
     description: "Modern terminal application for Windows",
     category: "terminal",
     tags: ["terminal", "windows", "microsoft", "powershell"],
-    icon: WindowsTerminalIcon,
     website: "https://aka.ms/terminal",
     documentation:
       "https://docs.microsoft.com/en-us/windows/terminal/customize-settings/color-schemes",
@@ -159,9 +156,5 @@ export const windowsTerminalProvider: PreviewableProvider<{
       );
 
     return validateTheme(output.light) && validateTheme(output.dark);
-  },
-
-  preview: {
-    component: WindowsTerminalPreview,
   },
 };

--- a/packages/providers/src/providers/zed-provider.ts
+++ b/packages/providers/src/providers/zed-provider.ts
@@ -1,18 +1,15 @@
-import { ZedPreview } from "@/components/preview/zed/zed-preview";
-import { ZedIcon } from "@/components/shared/icons";
 import type { TinteTheme } from "@tinte/core";
 import type { ZedThemeFamily } from "@tinte/core";
-import type { PreviewableProvider } from "./types";
+import type { ThemeProvider } from "./types";
 import { tinteToZed } from "./zed";
 
-export const zedProvider: PreviewableProvider<ZedThemeFamily> = {
+export const zedProvider: ThemeProvider<ZedThemeFamily> = {
   metadata: {
     id: "zed",
     name: "Zed",
     description: "High-performance multiplayer code editor",
     category: "editor",
     tags: ["editor", "code", "multiplayer", "rust"],
-    icon: ZedIcon,
     website: "https://zed.dev/",
     documentation: "https://zed.dev/docs/themes",
     experimental: true,
@@ -43,9 +40,5 @@ export const zedProvider: PreviewableProvider<ZedThemeFamily> = {
       content: JSON.stringify(converted, null, 2),
       mimeType: "application/json",
     };
-  },
-
-  preview: {
-    component: ZedPreview,
   },
 };

--- a/packages/providers/src/providers/zed-provider.ts
+++ b/packages/providers/src/providers/zed-provider.ts
@@ -1,5 +1,4 @@
-import type { TinteTheme } from "@tinte/core";
-import type { ZedThemeFamily } from "@tinte/core";
+import type { TinteTheme, ZedThemeFamily } from "@tinte/core";
 import type { ThemeProvider } from "./types";
 import { tinteToZed } from "./zed";
 

--- a/packages/providers/src/react/index.tsx
+++ b/packages/providers/src/react/index.tsx
@@ -1,0 +1,120 @@
+import { AlacrittyPreview } from "@/components/preview/alacritty/alacritty-preview";
+import { BananaPreview } from "@/components/preview/banana/banana-preview";
+import { BrandGuidelinesPreview } from "@/components/preview/brand-guidelines/brand-guidelines-preview";
+import { CodexPreview } from "@/components/preview/codex/codex-preview";
+import { DesignSystemPreview } from "@/components/preview/design-system/design-system-preview";
+import { GimpPreview } from "@/components/preview/gimp/gimp-preview";
+import { KittyPreview } from "@/components/preview/kitty/kitty-preview";
+import { ShadcnPreview } from "@/components/preview/shadcn/shadcn-preview";
+import { ShikiPreview } from "@/components/preview/shiki/shiki-preview";
+import { SlackPreview } from "@/components/preview/slack/slack-preview";
+import { VSCodePreview } from "@/components/preview/vscode/vscode-preview";
+import { WarpPreview } from "@/components/preview/warp/warp-preview";
+import { WindowsTerminalPreview } from "@/components/preview/windows-terminal/windows-terminal-preview";
+import { ZedPreview } from "@/components/preview/zed/zed-preview";
+import {
+  AlacrittyIcon,
+  BananaIcon,
+  CodexIcon,
+  GIMPIcon,
+  KittyIcon,
+  ShadcnIcon,
+  ShikiIcon,
+  SlackIcon,
+  VSCodeIcon,
+  WarpIcon,
+  WindowsTerminalIcon,
+  ZedIcon,
+} from "@/components/shared/icons";
+import { alacrittyProvider } from "../providers/alacritty";
+import { bananaProvider } from "../providers/banana";
+import { brandGuidelinesProvider } from "../providers/brand-guidelines";
+import { codexProvider } from "../providers/codex";
+import { designSystemProvider } from "../providers/design-system";
+import { gimpProvider } from "../providers/gimp";
+import { kittyProvider } from "../providers/kitty";
+import { shadcnProvider } from "../providers/shadcn";
+import { shikiProvider } from "../providers/shiki";
+import { slackProvider } from "../providers/slack";
+import type { PreviewableProvider } from "../providers/types";
+import { vscodeProvider } from "../providers/vscode";
+import { warpProvider } from "../providers/warp";
+import { windowsTerminalProvider } from "../providers/windows-terminal";
+import { zedProvider } from "../providers/zed-provider";
+
+export const previewableProviders: PreviewableProvider[] = [
+  {
+    ...bananaProvider,
+    icon: BananaIcon,
+    preview: { component: BananaPreview },
+  },
+  {
+    ...alacrittyProvider,
+    icon: AlacrittyIcon,
+    preview: { component: AlacrittyPreview },
+  },
+  {
+    ...brandGuidelinesProvider,
+    preview: { component: BrandGuidelinesPreview },
+  },
+  {
+    ...designSystemProvider,
+    preview: { component: DesignSystemPreview },
+  },
+  {
+    ...gimpProvider,
+    icon: GIMPIcon,
+    preview: { component: GimpPreview },
+  },
+  {
+    ...codexProvider,
+    icon: CodexIcon,
+    preview: { component: CodexPreview },
+  },
+  {
+    ...slackProvider,
+    icon: SlackIcon,
+    preview: { component: SlackPreview },
+  },
+  {
+    ...kittyProvider,
+    icon: KittyIcon,
+    preview: { component: KittyPreview },
+  },
+  {
+    ...warpProvider,
+    icon: WarpIcon,
+    preview: { component: WarpPreview },
+  },
+  {
+    ...shikiProvider,
+    icon: ShikiIcon,
+    preview: { component: ShikiPreview },
+  },
+  {
+    ...shadcnProvider,
+    icon: ShadcnIcon,
+    preview: { component: ShadcnPreview },
+  },
+  {
+    ...windowsTerminalProvider,
+    icon: WindowsTerminalIcon,
+    preview: { component: WindowsTerminalPreview },
+  },
+  {
+    ...vscodeProvider,
+    icon: VSCodeIcon,
+    preview: { component: VSCodePreview },
+  },
+  {
+    ...zedProvider,
+    icon: ZedIcon,
+    preview: { component: ZedPreview },
+  },
+];
+
+export function getPreviewableProviderReact(
+  id: string,
+): PreviewableProvider | undefined {
+  return previewableProviders.find((provider) => provider.metadata.id === id);
+}


### PR DESCRIPTION
## Why

The theme converters lived in modules that imported React components from the web app, so nothing outside Next.js could reach them. tinte could not generate a theme file from the terminal, despite that being the thing it is named for.

The CLI had already started working around this: it kept its own copy of the Zed provider at `packages/cli/src/lib/providers/zed.ts`, and that copy had drifted **39 lines** from the one in `packages/providers`. Two copies of the same converter, already out of sync.

## What the coupling actually was

Superficial and uniform. In all 14 coupled providers, React entered through exactly two presentation fields:

- `metadata.icon`
- `preview.component`

No provider used React in its conversion logic. So this is a move of two fields, not a rewrite.

## Changes

- Remove `icon` from `ProviderMetadata` and move it to `PreviewableProvider` next to `preview.component`. That field was the thing dragging React into the base type.
- Strip both presentation fields from the 14 provider modules and retype them as `ThemeProvider`.
- Add `@tinte/providers/react`, which reattaches every icon and preview component for the web app.
- Register all 14 providers in the pure registry (previously only 5 were registered).
- Rename `zed-provider.tsx` to `.ts`, since it no longer holds JSX.
- Migrate the 4 web files that consumed the old shape.
- Add `tinte export`.

## New command

```bash
tinte export --list                          # 14 providers
tinte export --provider vscode --out themes/
tinte export --provider zed --json
```

Reads the same `tinte.config.json` the compiler uses, and also accepts a bare `{light, dark}` object. Exits `1` on an unknown provider or unreadable config, so it gates CI:

```bash
tinte export --provider vscode --out themes/
git diff --exit-code themes/
```

## Verification

| Check | Result |
|---|---|
| All 18 provider modules import under plain Node | pass |
| Compiled binary runs outside the monorepo (`node dist/cli.js`) | pass |
| `packages/providers` typecheck | exit 0 |
| `apps/web` typecheck | exit 0 |
| Tests | 49 pass, 0 fail |
| `grep -rn "@/components" packages/providers/src/providers/` | no matches |
| Export output stable across runs | same sha256 |

Provider diffs were checked whitespace-insensitive to confirm no conversion logic changed. `brand-guidelines.ts` shows a large line count purely because Biome reindented the object literal after the type annotation got shorter.

## Follow-up, not in this PR

`provider-experiment-tabs.tsx` reads `provider.meta.*` in 9 places where the type is `metadata`. It is invisible to `tsc` because those values are typed `any`. This predates the branch (present in `origin/main`) and is left alone here.