### PR TITLE
fix(vscode): emit semanticHighlighting so semantic colors apply

### DIFF
--- a/packages/providers/src/providers/vscode.ts
+++ b/packages/providers/src/providers/vscode.ts
@@ -51,6 +51,11 @@ export interface VSCodeTheme {
   name: string;
   displayName: string;
   type: "light" | "dark";
+  /**
+   * VS Code discards a theme's semantic token colors unless this is true, so
+   * semantic scopes silently have no effect without it.
+   */
+  semanticHighlighting: boolean;
   colors: Record<string, string>;
   tokenColors: VSCodeTokenColor[];
 }
@@ -414,6 +419,7 @@ function convertTinteToVSCode(
     name: `${name} Light`,
     displayName: `${name} (Light)`,
     type: "light",
+    semanticHighlighting: true,
     colors: getVSCodeColors(tinteTheme.light, "light"),
     tokenColors: generateTokenColors(
       tinteTheme.light,
@@ -426,6 +432,7 @@ function convertTinteToVSCode(
     name: `${name} Dark`,
     displayName: `${name} (Dark)`,
     type: "dark",
+    semanticHighlighting: true,
     colors: getVSCodeColors(tinteTheme.dark, "dark"),
     tokenColors: generateTokenColors(
       tinteTheme.dark,


### PR DESCRIPTION
VS Code discards a theme's semantic token colors unless the theme sets `semanticHighlighting: true`. Without it, any semantic scope a consumer adds silently has no effect, while the theme file looks complete.

Same class of bug as #82: an omitted field makes VS Code quietly fall back to its own behavior.

Surfaced from [Railly/one-hunter-vscode#15](https://github.com/Railly/one-hunter-vscode/issues/15) and [#41](https://github.com/Railly/one-hunter-vscode/issues/41), where semantic token requests went nowhere for three years because the flag was never set. That repo's own generator is fixed; the five variants it gets from this provider need it here.

## Verification

```
semanticHighlighting: true
ANSI slots: 16
```

Typecheck exit 0, 49 tests pass.