### PR TITLE
feat: tinte build --to <provider>, and themes for humans on the landing

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -67,6 +67,34 @@ $ tinte lint src/   # after the fix
 tinte lint: clean
 exit 0`;
 
+// The full human path: read a reference, emit the artifact, install it. The
+// VS Code artifact is the one the classic installer accepts, so the last line
+// is a real command and not an illustration.
+const THEME_SNIPPET = `$ tinte from --normalize candidates.json --name acme
+
+$ tinte build --to vscode --config acme.json
+
+acme-vscode.json
+
+$ tinte acme-vscode.json --code
+
+Theme installed successfully!`;
+
+// Registered --to targets, mirroring src/lib/build-targets.ts exactly. Only
+// providers whose artifact is a theme a tool consumes are listed; the shadcn,
+// design-system and brand-guidelines providers emit UI documents instead.
+const THEME_TARGETS = [
+  { id: "vscode", does: "VS Code and Cursor, installable with tinte --code" },
+  { id: "zed", does: "Zed theme family, light and dark" },
+  { id: "kitty", does: "Kitty terminal conf" },
+  { id: "warp", does: "Warp terminal YAML" },
+  { id: "alacritty", does: "Alacritty terminal YAML" },
+  { id: "windows-terminal", does: "Windows Terminal color scheme" },
+  { id: "slack", does: "Slack sidebar theme" },
+  { id: "gimp", does: "GIMP palette" },
+  { id: "shiki", does: "Shiki syntax highlighting CSS" },
+];
+
 const COMMANDS = [
   {
     command: "tinte from --emit-script",
@@ -83,6 +111,14 @@ const COMMANDS = [
   {
     command: "tinte build --out <dir>",
     does: "Emits design.md and tokens.css as two loose files instead.",
+  },
+  {
+    command: "tinte build --to <provider>",
+    does: "Emits a theme artifact for one provider: vscode, zed, kitty, and six more.",
+  },
+  {
+    command: "tinte build --to",
+    does: "Lists every provider target available to build against.",
   },
   {
     command: "tinte lint <paths>",
@@ -143,7 +179,8 @@ export default function Home() {
             <p className="mt-6 max-w-[34ch] text-base leading-relaxed text-muted-foreground">
               A coding agent writes on-brand UI when it can read your tokens as
               an API and your composition rules as instructions. Tinte emits
-              both as one installable artifact.
+              both as one installable artifact, and compiles the same identity
+              into a theme for your editor and terminal.
             </p>
 
             <div className="mt-10 flex flex-wrap items-center gap-3">
@@ -215,6 +252,53 @@ export default function Home() {
               </li>
             ))}
           </ol>
+        </section>
+
+        <section className="mt-20 border-t border-border pt-14 pb-4">
+          <h2 className="text-2xl font-medium leading-tight tracking-tight">
+            The same identity, as a theme for humans
+          </h2>
+          <p className="mt-4 max-w-[56ch] text-base leading-relaxed text-muted-foreground">
+            A design system an agent can read is also a theme you can look at
+            all day. One config compiles both ways:{" "}
+            <code className="font-mono text-[13px]">--plugin</code> for the
+            agent, <code className="font-mono text-[13px]">--to</code> for the
+            editor and terminal you already use.
+          </p>
+
+          <div className="mt-10 grid gap-x-10 gap-y-8 lg:grid-cols-[minmax(0,26rem)_minmax(0,1fr)] lg:items-start">
+            <div className="min-w-0">
+              <h3 className="text-base font-medium tracking-tight">
+                Nine targets, one command
+              </h3>
+              <p className="mt-3 text-base leading-relaxed text-muted-foreground">
+                Each target is a provider that converts the thirteen tokens into
+                that tool's own format. The VS Code artifact is accepted by the
+                classic installer, so the theme lands in your editor without a
+                marketplace round trip.
+              </p>
+              <dl className="mt-6 grid gap-x-6 gap-y-2 sm:grid-cols-[minmax(0,10rem)_minmax(0,1fr)]">
+                {THEME_TARGETS.map(({ id, does }) => (
+                  <div key={id} className="contents">
+                    {/* Target ids are values, not commands, so they stay in
+                        foreground rather than taking the command color. */}
+                    <dt className="min-w-0 font-mono text-[13px] leading-[1.7]">
+                      {id}
+                    </dt>
+                    <dd className="min-w-0 text-sm leading-[1.7] text-muted-foreground">
+                      {does}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+
+            <TerminalBlock
+              snippet={THEME_SNIPPET}
+              label="Reference to installed theme"
+              className="p-5"
+            />
+          </div>
         </section>
 
         <section className="mt-20 border-t border-border py-14">

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@tinte/core": "workspace:*",
+    "@tinte/providers": "workspace:*",
     "@types/culori": "^4.0.0",
     "@types/node": "^20.0.0",
     "bun-types": "^1.3.14",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,6 +37,11 @@ Usage:
   bunx tinte list                    # List installed Tinte themes
   bunx tinte cleanup                 # Clean up temporary files
 
+Themes for humans (identity -> provider artifact):
+  bunx tinte build --to              # List available provider targets
+  bunx tinte build --to vscode       # Emit a VS Code theme, installable below
+  bunx tinte build --to zed --out themes/
+
 Design system compiler (Agent Plugins):
   bunx tinte build --plugin          # Compile identity config to an Agent Plugin
   bunx tinte lint [paths...]         # Scan for colors that bypass the token system

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -343,3 +343,136 @@ describe("buildCommand validation", () => {
     expect(errors.join("\n")).toContain("not valid JSON");
   });
 });
+
+describe("buildCommand --to", () => {
+  it("emits a VS Code artifact the classic installer can consume", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const out = join(workDir, "themes");
+
+    const code = await buildCommand([
+      "--to",
+      "vscode",
+      "--config",
+      config,
+      "--out",
+      out,
+    ]);
+    expect(code).toBe(0);
+
+    const artifact = JSON.parse(
+      await readFile(join(out, "cronwatch-vscode.json"), "utf8"),
+    );
+
+    // The installer reads `rawTheme || themeData` and needs light/dark blocks
+    // to generate a VSIX; a bare VS Code theme has neither.
+    expect(artifact.rawTheme.light.bg).toBe(cronwatchBlock.bg);
+    expect(artifact.rawTheme.dark.bg).toBe(cronwatchDarkBlock.bg);
+    expect(artifact.name).toBe("Cronwatch");
+
+    expect(
+      Object.keys(artifact.vscode_overrides.colors).length,
+    ).toBeGreaterThan(0);
+    expect(artifact.vscode_overrides.tokenColors.length).toBeGreaterThan(0);
+  });
+
+  it("emits a Zed theme family carrying the identity name", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const out = join(workDir, "themes");
+
+    const code = await buildCommand([
+      "--to",
+      "zed",
+      "--config",
+      config,
+      "--out",
+      out,
+    ]);
+    expect(code).toBe(0);
+
+    const theme = JSON.parse(
+      await readFile(join(out, "cronwatch.json"), "utf8"),
+    );
+    expect(theme.$schema).toContain("zed.dev/schema/themes");
+    expect(theme.name).toBe("Cronwatch");
+    expect(
+      theme.themes.map((t: { appearance: string }) => t.appearance),
+    ).toEqual(["light", "dark"]);
+  });
+
+  it("emits a kitty conf with the mapped foreground and background", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const out = join(workDir, "themes");
+
+    const code = await buildCommand([
+      "--to",
+      "kitty",
+      "--config",
+      config,
+      "--out",
+      out,
+    ]);
+    expect(code).toBe(0);
+
+    // The kitty provider emits the dark variant, terminals being dark by
+    // convention.
+    const conf = await readFile(join(out, "tinte-theme-kitty.conf"), "utf8");
+    expect(conf).toContain(`background ${cronwatchDarkBlock.bg}`);
+    expect(conf).toContain(`foreground ${cronwatchDarkBlock.tx}`);
+  });
+
+  it("writes to an explicit file path when --out has an extension", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const target = join(workDir, "nested", "my-theme.json");
+
+    const code = await buildCommand([
+      "--to",
+      "vscode",
+      "--config",
+      config,
+      "--out",
+      target,
+    ]);
+    expect(code).toBe(0);
+
+    const artifact = JSON.parse(await readFile(target, "utf8"));
+    expect(artifact.rawTheme).toBeDefined();
+  });
+
+  it("lists targets when --to has no value, without needing a config", async () => {
+    const logs: string[] = [];
+    const original = console.log;
+    console.log = (...parts: unknown[]) => {
+      logs.push(parts.map(String).join(" "));
+    };
+
+    let code: number;
+    try {
+      code = await buildCommand(["--to"]);
+    } finally {
+      console.log = original;
+    }
+
+    expect(code).toBe(0);
+    expect(logs.join("\n")).toContain("vscode");
+    expect(logs.join("\n")).toContain("kitty");
+  });
+
+  it("rejects a provider that is not a valid target", async () => {
+    const config = await writeConfig("tinte.config.json", cronwatchIdentity);
+    const errors: string[] = [];
+    const original = console.error;
+    console.error = (...parts: unknown[]) => {
+      errors.push(parts.map(String).join(" "));
+    };
+
+    let code: number;
+    try {
+      code = await buildCommand(["--to", "shadcn", "--config", config]);
+    } finally {
+      console.error = original;
+    }
+
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("unknown --to target");
+  });
+});

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, extname, join, resolve } from "node:path";
 import {
   type TinteBlock,
   type TinteIdentity,
@@ -8,6 +8,12 @@ import {
   type Typography,
 } from "@tinte/core";
 import { formatCss, oklch, parse } from "culori";
+import {
+  type BuildTargetId,
+  buildForTarget,
+  isBuildTarget,
+  listTargets,
+} from "../lib/build-targets";
 import { moduleDir } from "../lib/module-dir";
 
 const PLUGIN_SCHEMA_URL =
@@ -22,14 +28,24 @@ interface BuildOptions {
   configPath: string;
   outDir: string;
   plugin: boolean;
+  /** Provider id from `--to`, or "" when the flag was passed with no value. */
+  to?: BuildTargetId | "";
+}
+
+function printTargets(): void {
+  console.log("Available --to targets:\n");
+  const width = Math.max(...listTargets().map((t) => t.id.length));
+  for (const target of listTargets()) {
+    console.log(`  ${target.id.padEnd(width)}  ${target.description}`);
+  }
 }
 
 /**
- * `tinte build [--plugin] [--config <file>] [--out <dir>]`
+ * `tinte build [--plugin] [--to <provider>] [--config <file>] [--out <path>]`
  *
  * Reads a TinteIdentity config, validates it against the V4 schema, and emits
- * either a full Agent Plugin directory (--plugin) or the two loose artifacts
- * (design.md + tokens.css).
+ * either a full Agent Plugin directory (--plugin), a provider theme artifact
+ * (--to), or the two loose artifacts (design.md + tokens.css).
  */
 export async function buildCommand(args: string[]): Promise<number> {
   let options: BuildOptions;
@@ -38,6 +54,13 @@ export async function buildCommand(args: string[]): Promise<number> {
   } catch (error) {
     console.error(`Error: ${messageOf(error)}`);
     return 1;
+  }
+
+  // `--to` with no value is a listing request, so it answers before the
+  // config is required.
+  if (options.to === "") {
+    printTargets();
+    return 0;
   }
 
   const configPath = resolve(process.cwd(), options.configPath);
@@ -67,6 +90,11 @@ export async function buildCommand(args: string[]): Promise<number> {
   }
 
   const identity = parsed.data;
+
+  if (options.to) {
+    return emitProviderArtifact(identity, options.to, options.outDir);
+  }
+
   const outDir = resolve(
     process.cwd(),
     options.outDir ?? `./${identity.name}-plugin`,
@@ -114,15 +142,83 @@ export async function buildCommand(args: string[]): Promise<number> {
   return 0;
 }
 
+/**
+ * `--to <provider>`: route the identity's theme through a provider and write
+ * the artifact. `--out` accepts either a directory (the provider names the
+ * file) or an explicit file path, detected by a trailing separator or the
+ * presence of an extension.
+ */
+async function emitProviderArtifact(
+  identity: TinteIdentity,
+  target: BuildTargetId,
+  out: string,
+): Promise<number> {
+  const themeName = identity.theme.name ?? identity.name;
+
+  let artifact: { filename: string; content: string };
+  try {
+    artifact = buildForTarget(target, identity.theme, themeName);
+  } catch (error) {
+    console.error(`Error: ${messageOf(error)}`);
+    return 1;
+  }
+
+  const destination = resolveDestination(out, artifact.filename);
+
+  try {
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(destination, artifact.content, "utf8");
+  } catch (error) {
+    console.error(`Error: could not write ${destination}. ${messageOf(error)}`);
+    return 1;
+  }
+
+  console.log(destination);
+  if (target === "vscode") {
+    console.log(`\nInstall it with:\n  tinte ${destination} --code`);
+  }
+
+  return 0;
+}
+
+function resolveDestination(out: string, filename: string): string {
+  if (!out) {
+    return resolve(process.cwd(), filename);
+  }
+
+  const looksLikeFile =
+    !out.endsWith("/") && extname(out) !== "" && !existsSync(out);
+  const isExistingDir = existsSync(out) && statSync(out).isDirectory();
+
+  if (looksLikeFile && !isExistingDir) {
+    return resolve(process.cwd(), out);
+  }
+
+  return resolve(process.cwd(), out, filename);
+}
+
 function parseArgs(args: string[]): BuildOptions {
   let configPath = "./tinte.config.json";
   let outDir = "";
   let plugin = false;
+  let to: BuildTargetId | "" | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--plugin") {
       plugin = true;
+    } else if (arg === "--to") {
+      // `--to` with no value lists the targets instead of erroring.
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        to = "";
+      } else {
+        to = assertTarget(value);
+        i++;
+      }
+    } else if (arg.startsWith("--to=")) {
+      const value = arg.slice("--to=".length);
+      to = value ? assertTarget(value) : "";
     } else if (arg === "--config" || arg === "--out") {
       const value = args[i + 1];
       if (!value || value.startsWith("--")) {
@@ -140,7 +236,17 @@ function parseArgs(args: string[]): BuildOptions {
     }
   }
 
-  return { configPath, outDir, plugin };
+  return { configPath, outDir, plugin, to };
+}
+
+function assertTarget(value: string): BuildTargetId {
+  if (!isBuildTarget(value)) {
+    const available = listTargets()
+      .map((t) => t.id)
+      .join(", ");
+    throw new Error(`unknown --to target "${value}". Available: ${available}`);
+  }
+  return value;
 }
 
 /**

--- a/packages/cli/src/lib/build-targets.ts
+++ b/packages/cli/src/lib/build-targets.ts
@@ -1,0 +1,135 @@
+import type { TinteBlock, TinteTheme } from "@tinte/core";
+import { getProvider, hasProvider } from "@tinte/providers";
+
+/**
+ * Providers that convert a TinteTheme into a serializable artifact with no
+ * React and no `@/` alias in their import graph, so they load from a plain
+ * Node/Bun process.
+ *
+ * Deliberately excluded:
+ *   shadcn, design-system, brand-guidelines  emit UI/HTML documents, not a
+ *     theme artifact a tool consumes.
+ *   banana, codex                            preview/experimental surfaces
+ *     whose output is not an installable theme.
+ */
+const TARGET_IDS = [
+  "vscode",
+  "zed",
+  "kitty",
+  "warp",
+  "alacritty",
+  "windows-terminal",
+  "slack",
+  "gimp",
+  "shiki",
+] as const;
+
+export type BuildTargetId = (typeof TARGET_IDS)[number];
+
+interface TargetInfo {
+  id: BuildTargetId;
+  description: string;
+  /** Whether `tinte <file> --code` can install the emitted artifact. */
+  installable: boolean;
+}
+
+const TARGET_INFO: Record<BuildTargetId, Omit<TargetInfo, "id">> = {
+  vscode: {
+    description: "VS Code / Cursor theme, installable with tinte <file> --code",
+    installable: true,
+  },
+  zed: { description: "Zed theme family JSON", installable: false },
+  kitty: { description: "Kitty terminal conf", installable: false },
+  warp: { description: "Warp terminal YAML", installable: false },
+  alacritty: { description: "Alacritty terminal YAML", installable: false },
+  "windows-terminal": {
+    description: "Windows Terminal color scheme",
+    installable: false,
+  },
+  slack: { description: "Slack sidebar theme", installable: false },
+  gimp: { description: "GIMP palette (.gpl)", installable: false },
+  shiki: { description: "Shiki syntax highlighting CSS", installable: false },
+};
+
+export function listTargets(): TargetInfo[] {
+  return TARGET_IDS.map((id) => ({ id, ...TARGET_INFO[id] }));
+}
+
+export function isBuildTarget(value: string): value is BuildTargetId {
+  return (TARGET_IDS as readonly string[]).includes(value);
+}
+
+export interface BuiltArtifact {
+  filename: string;
+  content: string;
+}
+
+/**
+ * The classic installer reads `themeData.rawTheme || themeData` and expects a
+ * TinteTheme (light/dark blocks) so it can generate a VSIX; a bare VS Code
+ * theme has no light/dark and the generator rejects it. So the VS Code target
+ * emits an envelope: the TinteTheme the installer needs, plus the converted
+ * colors/tokenColors as `vscode_overrides`, which the installer forwards.
+ */
+export function buildForTarget(
+  target: BuildTargetId,
+  theme: TinteTheme,
+  themeName: string,
+): BuiltArtifact {
+  if (!hasProvider(target)) {
+    throw new Error(`provider "${target}" is not registered`);
+  }
+
+  const provider = getProvider(target);
+  if (!provider) {
+    throw new Error(`provider "${target}" is not registered`);
+  }
+
+  // A config may carry no `theme.name`, and providers then fall back to their
+  // own default ("Custom Theme"), which loses the identity name in both the
+  // artifact and its filename. Naming the theme here keeps every target
+  // consistent with the identity.
+  const named: TinteTheme = { ...theme, name: themeName };
+  const output = provider.export(named);
+
+  if (target !== "vscode") {
+    return { filename: output.filename, content: output.content };
+  }
+
+  let converted: { colors?: unknown; tokenColors?: unknown };
+  try {
+    converted = JSON.parse(output.content);
+  } catch (error) {
+    throw new Error(
+      `vscode provider returned invalid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const envelope = {
+    name: themeName,
+    rawTheme: {
+      light: theme.light,
+      dark: theme.dark,
+    } satisfies { light: TinteBlock; dark: TinteBlock },
+    vscode_overrides: {
+      colors: converted.colors,
+      tokenColors: converted.tokenColors,
+    },
+  };
+
+  return {
+    filename: `${slugify(themeName)}-vscode.json`,
+    content: `${JSON.stringify(envelope, null, 2)}\n`,
+  };
+}
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "theme"
+  );
+}


### PR DESCRIPTION
Closes #72.

## Implementation

`tinte build --to <provider>` routes an identity's theme through the providers in `packages/providers` and writes the artifact, closing the `from` -> `build` -> install pipeline.

### The VS Code target is an envelope, not the raw provider output

The acceptance criterion is that the artifact installs via the classic installer. It does not, if you write the provider output directly. The installer reads `themeData.rawTheme || themeData` and passes it to the VSIX generator as a **TinteTheme**, so it needs `light`/`dark` blocks. A raw VS Code theme has `colors`/`tokenColors` and neither, and the generator rejects it:

```
$ tinte ./raw-vscode-theme.json --code
Installing Tinte Theme Dark to VS Code...
Error: Failed to generate theme: Internal Server Error
```

So `--to vscode` emits an envelope carrying the TinteTheme the installer needs plus the converted colors as `vscode_overrides`, which the installer already forwards.

### Registered targets

Nine, all verified to export from a plain Node/Bun process: `vscode`, `zed`, `kitty`, `warp`, `alacritty`, `windows-terminal`, `slack`, `gimp`, `shiki`.

Excluded, and why: `shadcn`, `design-system` and `brand-guidelines` emit UI/HTML documents rather than a theme artifact a tool consumes; `banana` and `codex` are preview surfaces. The `@/` alias contamination is confined to `src/react/index.tsx`, a separate `./react` export subpath, so the main entrypoint imports clean and no converter had to be copied.

`--to` with no value lists the targets and does not require a config.

### Bug found along the way

A config without `theme.name` let providers fall back to their own `"Custom Theme"` default, losing the identity name in both artifact and filename (zed wrote `custom-theme.json` for an identity named `tinte`). Providers are now named from the identity before export.

## Evidence

Acceptance criteria, end to end:

```
$ tinte build --to vscode --config tinte.config.json --out ./out
./out/tinte-vscode.json

$ tinte ./out/tinte-vscode.json --code
Installing tinte to VS Code...
Theme installed successfully!

$ tinte list --code
Installed Tinte themes in VS Code:
  - tinte.tinte@0.0.1
```

The extension is really installed in VS Code, carrying 117 colors and 40 tokenColors. This was also run from a packed tarball installed into an empty directory outside the workspace, so the published artifact is proven self-contained, not just the source tree.

## Publish safety

`@tinte/providers` is a **devDependency**, matching `@tinte/core`: tsup inlines both via `noExternal`, so a runtime dep would publish an unresolvable `workspace:*` range. Verified `dependencies` in the packed manifest contains only `culori`, and the bundle has zero external `@tinte/*` requires. Version left at 1.3.0.

## Tests

35 pass, 0 fail. Six new cases cover the vscode envelope, the zed family, kitty, explicit `--out` file paths, target listing, and rejection of a non-target provider.

## Landing

The provider path was missing from the landing despite shipping in the CLI. Adds a co-primary section with the real chain and only the nine registered targets, rendered through the existing terminal tokenizer.

Note: `bun run --filter @tinte/web build` fails at prerender on `/legacy/themes` with a missing Clerk `publishableKey`. Verified this fails identically on clean `main`, so it is a local env gap and not a regression here.